### PR TITLE
 [Feat] 업무(Task) 생성 API 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HealthCheckModule } from './modules/healthCheck/healthCheck.module';
 import { typeORMConfig } from './config/typeorm.config';
+import { TasksModule } from './modules/tasks/tasks.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { typeORMConfig } from './config/typeorm.config';
       useFactory: typeORMConfig,
     }),
     HealthCheckModule,
+    TasksModule,
   ],
 })
 export class AppModule {}

--- a/src/modules/tasks/dtos/create-request.dto.ts
+++ b/src/modules/tasks/dtos/create-request.dto.ts
@@ -1,3 +1,0 @@
-export class CreateTaskDto {
-  stepId: number;
-}

--- a/src/modules/tasks/dtos/create-request.dto.ts
+++ b/src/modules/tasks/dtos/create-request.dto.ts
@@ -1,0 +1,3 @@
+export class CreateTaskDto {
+  stepId: number;
+}

--- a/src/modules/tasks/dtos/create-task.dto.ts
+++ b/src/modules/tasks/dtos/create-task.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateTaskRequestDto {
+  stepId: number;
+}
+
+export class CreateTaskResponseDto {
+  @ApiProperty({ example: 1, description: '생성된 업무 ID' })
+  taskId: number;
+
+  constructor(taskId: number) {
+    this.taskId = taskId;
+  }
+
+  // Entity → DTO 변환 정적 메서드
+  static fromEntity(entity: { id: number }): CreateTaskResponseDto {
+    return new CreateTaskResponseDto(entity.id);
+  }
+}

--- a/src/modules/tasks/tasks.controller.ts
+++ b/src/modules/tasks/tasks.controller.ts
@@ -1,0 +1,31 @@
+import { Body, Controller, Post, Req, UseGuards, Patch, Delete, Get} from '@nestjs/common';
+import { Request } from 'express';
+import { TasksService } from './tasks.service';
+import { CreateTaskDto } from './dtos/create-request.dto';
+import { ConfigService } from '@nestjs/config';
+//import { JwtAuthGuard } from 'src/common/guards/jwt-auth.guard';
+
+@Controller('/tasks')
+export class TasksController {
+    constructor(private readonly tasksService: TasksService,
+      private readonly configService: ConfigService) {}
+
+  @Post()
+  //@UseGuards(JwtAuthGuard)
+  async createTask(@Req() req: Request, @Body() dto: CreateTaskDto) {
+    const userId = this.configService.get('DEFAULT_USERID');
+    return await this.tasksService.createTask(userId, dto);
+  }
+
+  @Patch()
+  //@UseGuards(JwtAuthGuard)
+  async updateTask(@Req() req: Request, @Body() dto: CreateTaskDto) {
+    const userId = Number(process.env.DEFAULT_USERID); // 카카오 로그인 연동 전까지 하드코딩
+    return {
+      isSuccess: true,
+      error: null,
+      result: await this.tasksService.createTask(userId, dto),
+    };
+  }
+    
+}

--- a/src/modules/tasks/tasks.controller.ts
+++ b/src/modules/tasks/tasks.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Post, Req, UseGuards, Patch, Delete, Get} from '@nestjs/common';
 import { Request } from 'express';
 import { TasksService } from './tasks.service';
-import { CreateTaskDto } from './dtos/create-request.dto';
+import { CreateTaskRequestDto } from './dtos/create-task.dto';
 import { ConfigService } from '@nestjs/config';
 //import { JwtAuthGuard } from 'src/common/guards/jwt-auth.guard';
 
@@ -12,20 +12,8 @@ export class TasksController {
 
   @Post()
   //@UseGuards(JwtAuthGuard)
-  async createTask(@Req() req: Request, @Body() dto: CreateTaskDto) {
+  async createTask(@Req() req: Request, @Body() dto: CreateTaskRequestDto) {
     const userId = this.configService.get('DEFAULT_USERID');
     return await this.tasksService.createTask(userId, dto);
-  }
-
-  @Patch()
-  //@UseGuards(JwtAuthGuard)
-  async updateTask(@Req() req: Request, @Body() dto: CreateTaskDto) {
-    const userId = Number(process.env.DEFAULT_USERID); // 카카오 로그인 연동 전까지 하드코딩
-    return {
-      isSuccess: true,
-      error: null,
-      result: await this.tasksService.createTask(userId, dto),
-    };
-  }
-    
+  } 
 }

--- a/src/modules/tasks/tasks.entity.ts
+++ b/src/modules/tasks/tasks.entity.ts
@@ -9,21 +9,22 @@ import { Step } from "../steps/steps.entity";
 
 @Entity()
 export class Task extends BaseEntity{
-    @Column({ length: 35 })
+    @Column({ length: 35, default: '빈 업무' })
     name: string;
 
     @Column()
     deadline: Date;
 
+    
     @Column({
         type: 'enum',
         enum: Status,
         default: Status.NOTSTART,
     })
-    status: Status;
+    status: Status;   
 
-    @Column({ length: 500 })
-    memo: string;   //비고
+    @Column()
+    memo: string;
 
     @ManyToOne(() => Step, (step) => step.tasks, {onDelete: 'CASCADE'})
     step: Step;

--- a/src/modules/tasks/tasks.module.ts
+++ b/src/modules/tasks/tasks.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TasksController } from './tasks.controller';
+import { TasksService } from './tasks.service';
+import { Task } from './tasks.entity';
+import { Step } from '../steps/steps.entity';
+import { UserProject } from '../mappings/userProjects/userProjects.entity';
+import { ConfigModule } from '@nestjs/config';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Task, Step, UserProject]),
+          ConfigModule,],
+  controllers: [TasksController],
+  providers: [TasksService],
+})
+export class TasksModule {}

--- a/src/modules/tasks/tasks.service.ts
+++ b/src/modules/tasks/tasks.service.ts
@@ -1,0 +1,63 @@
+import {BadRequestException, ForbiddenException, Injectable} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DeepPartial} from 'typeorm';
+import { Task } from './tasks.entity';
+import { Step } from '../steps/steps.entity';
+import { UserProject } from '../mappings/userProjects/userProjects.entity'; 
+import { CreateTaskDto } from './dtos/create-request.dto';
+
+@Injectable()
+export class TasksService {
+  constructor(
+    @InjectRepository(Task)
+    private readonly taskRepository: Repository<Task>,
+
+    @InjectRepository(Step)
+    private readonly stepRepository: Repository<Step>,
+
+    @InjectRepository(UserProject)
+    private readonly userProjectRepository: Repository<UserProject>,
+  ) {}
+
+  async createTask(userId: number, createTaskDto: CreateTaskDto): Promise<{ taskId: number }> {
+    const { stepId } = createTaskDto;
+
+    const targetStep  = await this.stepRepository.findOne({
+      where: { id: stepId },
+      relations: ['project'],
+    });
+
+    if (!targetStep ) {
+      throw new BadRequestException({
+        errorCode: 'STEP_NOT_FOUND',
+        reason: '해당 step이 존재하지 않습니다.',
+      });
+    }
+
+    const projectId = targetStep .project.id;
+
+    const userPorject = await this.userProjectRepository.findOne({
+        where: {
+            user: { id: userId },
+            project: { id: projectId },
+        },
+    });
+
+    if (!userPorject) {
+        throw new ForbiddenException({
+          errorCode: 'NOT_PROJECT_MEMBER',
+          reason: '프로젝트 참여자가 아닙니다.',
+        });
+    }
+
+    const task = {
+    step: targetStep,
+    name: '빈 업무',
+    memo: " ",
+    deadline: new Date(),
+  };
+
+  const saved = await this.taskRepository.save(task);
+    return { taskId: saved.id };
+  }
+}

--- a/src/modules/tasks/tasks.service.ts
+++ b/src/modules/tasks/tasks.service.ts
@@ -4,7 +4,8 @@ import { Repository, DeepPartial} from 'typeorm';
 import { Task } from './tasks.entity';
 import { Step } from '../steps/steps.entity';
 import { UserProject } from '../mappings/userProjects/userProjects.entity'; 
-import { CreateTaskDto } from './dtos/create-request.dto';
+import { CreateTaskRequestDto, CreateTaskResponseDto  } from './dtos/create-task.dto';
+import { CommonResponse} from '../../common/response/common-response.dto'
 
 @Injectable()
 export class TasksService {
@@ -19,8 +20,8 @@ export class TasksService {
     private readonly userProjectRepository: Repository<UserProject>,
   ) {}
 
-  async createTask(userId: number, createTaskDto: CreateTaskDto): Promise<{ taskId: number }> {
-    const { stepId } = createTaskDto;
+  async createTask(userId: number, createTaskRequestDto: CreateTaskRequestDto): Promise<{ taskId: number }> {
+    const { stepId } = createTaskRequestDto;
 
     const targetStep  = await this.stepRepository.findOne({
       where: { id: stepId },
@@ -30,7 +31,7 @@ export class TasksService {
     if (!targetStep ) {
       throw new BadRequestException({
         errorCode: 'STEP_NOT_FOUND',
-        reason: '해당 step이 존재하지 않습니다.',
+        message: '해당 step이 존재하지 않습니다.',
       });
     }
 
@@ -46,7 +47,7 @@ export class TasksService {
     if (!userPorject) {
         throw new ForbiddenException({
           errorCode: 'NOT_PROJECT_MEMBER',
-          reason: '프로젝트 참여자가 아닙니다.',
+          message: '프로젝트 참여자가 아닙니다.',
         });
     }
 
@@ -56,8 +57,7 @@ export class TasksService {
     memo: " ",
     deadline: new Date(),
   };
-  
-  const saved = await this.taskRepository.save(task);
+   const saved = await this.taskRepository.save(task);
     return { taskId: saved.id };
   }
 }

--- a/src/modules/tasks/tasks.service.ts
+++ b/src/modules/tasks/tasks.service.ts
@@ -56,7 +56,7 @@ export class TasksService {
     memo: " ",
     deadline: new Date(),
   };
-
+  
   const saved = await this.taskRepository.save(task);
     return { taskId: saved.id };
   }


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #8 

## ✅ 작업 내용
- 업무 controller, service, module, dto생성

## 📸 스크린샷
-성공
![주석 2025-07-10 141916](https://github.com/user-attachments/assets/c1e75946-b97d-4b43-8e42-c86bdb2f897d) 
실패
![image](https://github.com/user-attachments/assets/ad074928-f7d5-4244-8cf1-c38871dc1c95)



## 📎 기타 참고사항
- userId는 환경 변수에 DEFAULT_USERID=1
 이런식으로 우선 하드코딩 해뒀습니다 카카오 로그인 연결 후에 수정 예정입니다
- 공통응답 코드가 제대로 구현되지 않아 추후 카카오 로그인 연결하면서 수정 예정입니다
