### PR TITLE
[Feat] 프로젝트 참여 구현 

### DIFF
--- a/src/modules/projects/dto/all-project-response.dto.ts
+++ b/src/modules/projects/dto/all-project-response.dto.ts
@@ -1,0 +1,93 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Project } from '../entities/projects.entity';
+import { UserProject } from 'src/modules/mappings/userProjects/userProjects.entity';
+
+export class SimpleTaskDto {
+  @ApiProperty({ example: '담당업무' })
+  taskName: string;
+
+  static from(name: string): SimpleTaskDto {
+    const dto = new SimpleTaskDto();
+    dto.taskName = name;
+    return dto;
+  }
+}
+
+export class UserInProjectDto {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  email: string;
+
+  @ApiProperty()
+  school: string;
+
+  @ApiProperty({ nullable: true })
+  imageUrl: string | null;
+
+  @ApiProperty({ type: [SimpleTaskDto] })
+  tasks: SimpleTaskDto[];
+
+  @ApiProperty({ example: 'LEAD' })
+  permission: string;
+
+  @ApiProperty({ example: '기획' })
+  role: string;
+  static from(entity: UserProject): UserInProjectDto {
+    const dto = new UserInProjectDto();
+    const user = entity.user;
+
+    dto.id = user.id;
+    dto.name = user.name;
+    dto.email = user.email;
+    dto.school = user.school;
+    dto.imageUrl = user.imageUrl;
+    dto.permission = entity.permission;
+    dto.role = entity.role;
+    dto.tasks = user.managers?.map(m => SimpleTaskDto.from(m.task.name)) ?? [];
+    return dto;
+  }
+}
+
+
+export class PostDto {
+  @ApiProperty()
+  author: string;
+
+  @ApiProperty()
+  content: string;
+
+  static from(data: any): PostDto {
+    const dto = new PostDto();
+    dto.author = data.author;
+    dto.content = data.content;
+    return dto;
+  }
+}
+
+export class AllProjectResponseDto {
+  @ApiProperty({ type: Project })
+  project: Project;
+
+  @ApiProperty({ type: [UserInProjectDto] })
+  users: UserInProjectDto[];
+
+  @ApiProperty({ type: [PostDto] })
+  posts: PostDto[];
+
+  static fromEntity(entity: {
+    project: Project;
+    users: UserInProjectDto[];
+    posts: PostDto[];
+  }): AllProjectResponseDto {
+    const dto = new AllProjectResponseDto();
+    dto.project = entity.project;
+    dto.users = entity.users;
+    dto.posts = entity.posts;
+    return dto;
+  }
+}

--- a/src/modules/projects/entities/projects.entity.ts
+++ b/src/modules/projects/entities/projects.entity.ts
@@ -21,8 +21,8 @@ export class Project extends BaseEntity{
     @Column({ default: false })
     isCompleted: boolean;
 
-    @Column()
-    completedAt: Date;
+    @Column({ type: 'datetime', nullable: true })
+    completedAt: Date | null;
 
     @OneToMany(() => PersonalRecall, (personalRecall) => personalRecall.project)
     personalRecalls: PersonalRecall[];

--- a/src/modules/projects/projects.controller.ts
+++ b/src/modules/projects/projects.controller.ts
@@ -1,11 +1,17 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import { Controller, Post, Get, Body, Param, Req, NotFoundException, Query, All } from '@nestjs/common';
 import { ProjectsService } from './projects.service';
 import { CreateProjectDto, CreateProjectResponseDto } from './dto/create-project.dto';
-import { ApiBody } from '@nestjs/swagger';
+import { AllProjectResponseDto } from './dto/all-project-response.dto';
+import { ApiBody, ApiQuery } from '@nestjs/swagger';
 import { ApiCommonResponse, ApiCommonErrorResponse } from '../../common/response/swagger-responce.helper';
+import { ConfigService } from '@nestjs/config';
+
 @Controller('/projects')
 export class ProjectsController {
-  constructor(private readonly projectsService: ProjectsService) {}
+  constructor(
+    private readonly projectsService: ProjectsService,
+    private readonly configService: ConfigService
+  ) {}
 
   @Post()
   @ApiBody({ type: CreateProjectDto })
@@ -16,6 +22,28 @@ export class ProjectsController {
     //@ReqUser() user: UserPayload,  // 여기서 user.id를 사용
   ) {
     const userId = parseInt(process.env.DEFAULT_USER_ID || '1', 10);
+    if (!userId) {
+      throw new NotFoundException('인증되지 않은 사용자입니다.');}
     return await this.projectsService.createProject(dto, userId);
   }
+
+  @Get('/join')
+  @ApiQuery({ name: 'inviteCode', required: true, example: 'abcd1234' })
+  @ApiCommonResponse(AllProjectResponseDto)
+  @ApiCommonErrorResponse('NOT_FOUND', '유효하지 않은 초대코드입니다.')
+  async joinProject(@Query('inviteCode') inviteCode: string) {
+    const userId = parseInt(this.configService.get('DEFAULT_USER_ID') || '1', 10);
+
+  const project = await this.projectsService.getProjectByInviteCode(inviteCode);
+  if (!project) throw new NotFoundException('유효하지 않은 초대코드입니다.');
+
+  const projectId = project.id;
+  const alreadyJoined = await this.projectsService.isUserInProject(userId, projectId);
+  if (!alreadyJoined) {
+    await this.projectsService.addUserToProject(userId, projectId, 'member');
+  }
+
+  return await this.projectsService.getProjectFullData(projectId);
+}
+
 }

--- a/src/modules/projects/projects.module.ts
+++ b/src/modules/projects/projects.module.ts
@@ -4,10 +4,12 @@ import { ProjectsController } from './projects.controller';
 import { ProjectsService } from './projects.service';
 import { Project } from './entities/projects.entity';
 import { UserProject } from '../mappings/userProjects/userProjects.entity'; 
+import { RedisModule } from '../redis/redis.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Project, UserProject]),
+    RedisModule
   ],
   controllers: [ProjectsController],
   providers: [ProjectsService],

--- a/src/modules/projects/projects.service.ts
+++ b/src/modules/projects/projects.service.ts
@@ -9,6 +9,7 @@ import {  CACHE_MANAGER  } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
 import { ConfigService } from '@nestjs/config';
 import { CommonResponse } from '../../common/response/common-response.dto';
+import { UserInProjectDto, AllProjectResponseDto ,  PostDto} from './dto/all-project-response.dto';
 @Injectable()
 export class ProjectsService {
   constructor(
@@ -18,14 +19,12 @@ export class ProjectsService {
     @InjectRepository(UserProject)
     private readonly userProjectRepository: Repository<UserProject>,
 
-    @Inject(CACHE_MANAGER)
-    private cacheManager: Cache,
 
-    private readonly configService: ConfigService,
-    
+    @Inject('REDIS_CLIENT')
+    private readonly redis: Cache, private readonly configService: ConfigService,
   ) {}
 
-  async createProject(dto:CreateProjectDto, userId: number) {
+  async createProject(dto:CreateProjectDto, userId: number):Promise<CommonResponse<CreateProjectResponseDto>> {
     const {name} = dto;
     const project = this.projectRepository.create({
       name,
@@ -49,13 +48,50 @@ export class ProjectsService {
     const code = generateRandomCode();
     const key = `invite:${code}`;
     const ttlSeconds = 60 * 60 * 24 *7 ;  //7일
-    await this.cacheManager.set(key, savedProject, ttlSeconds);
+    await this.redis.set(key, savedProject.id.toString(),  ttlSeconds );
 
     const baseUrl = this.configService.get('BASE_URL');
     const inviteCode = `${baseUrl}/projects/join/${code}`;
 
 
     return CommonResponse.success(CreateProjectResponseDto.fromEntity(project, inviteCode));
+  }
+
+  async getProjectByInviteCode(inviteCode: string): Promise<Project | null> {
+    const key = `invite:${inviteCode}`;
+    const projectId = await this.redis.get<Project>(key);
+    return projectId || null;
+  }
+
+  async isUserInProject(userId: number, projectId: number): Promise<boolean> {
+    return await this.userProjectRepository.exists({where: { user: { id: userId }, project: { id: projectId } }});
+  }
+  
+  async addUserToProject(userId: number, projectId: number, role: string): Promise<void> {
+    const userProject = this.userProjectRepository.create({
+      user: { id: userId },
+      project: { id: projectId },
+      permission: projectPermission.MEMBER,
+      role,
+    });
+    await this.userProjectRepository.save(userProject);
+  }
+
+  async getProjectFullData(projectId: number): Promise<CommonResponse<AllProjectResponseDto>> {
+  const project = await this.projectRepository.findOneOrFail({ where: { id: projectId } });
+
+  const userProjects = await this.userProjectRepository.find({
+    where: { project: { id: projectId } },
+    relations: ['user', 'user.managers', 'user.managers.task'],
+  });
+
+  const users = userProjects.map(UserInProjectDto.from);
+
+  const key = `posts:${projectId}`;
+  const postsRaw = await this.redis.get(key) || [];
+  const posts = Array.isArray(postsRaw) ? postsRaw.map(PostDto.from) : [];
+
+  return CommonResponse.success(AllProjectResponseDto.fromEntity({ project, users, posts }));
   }
 }
 

--- a/src/modules/redis/redis.module.ts
+++ b/src/modules/redis/redis.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { RedisProvider } from './redis.providers';
+
+@Module({
+  providers: [RedisProvider],
+  exports: ['REDIS_CLIENT'],
+})
+export class RedisModule {}

--- a/src/modules/redis/redis.providers.ts
+++ b/src/modules/redis/redis.providers.ts
@@ -1,0 +1,11 @@
+import { Provider } from '@nestjs/common';
+import { createClient } from 'redis';
+
+export const RedisProvider: Provider = {
+  provide: 'REDIS_CLIENT',
+  useFactory: async () => {
+    const client = createClient({ url: process.env.REDIS_URL });
+    await client.connect();
+    return client;
+  },
+};


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #18 

## ✅ 작업 내용
- redis 방식을 CACHE_MANAGER 주입에서 REDIS_CLIENT로 변경하였습니다 (이전 방식은 캐싱을 위한 임시 레디스 방식이고 key, value 지정하는 redis는 후자라고 하여 변경)
- url 클릭 시 회원일 경우 해당 프로젝트 팀원으로 참여
- 만료되어 없는 project id일 시 NOT_FOUND 에러AllProjectResponseDto를 썼고 추후 조회에도 같은 dto를 쓸 생각입니다

## 📸 스크린샷
![스크린샷_10-7-2025_21756_localhost](https://github.com/user-attachments/assets/1592bcfd-ffb6-46ea-801f-91fd7d852fe2)

프로젝트 생성 시 실제로 참여 url를 생성하여 redis에 저장되는지 테스트 화면
![스크린샷_10-7-2025_21726_localhost](https://github.com/user-attachments/assets/0ccd2872-9164-430e-a29d-6ff02051355f)

<img width="722" height="103" alt="스크린샷 2025-07-10 210842" src="https://github.com/user-attachments/assets/f7c8bdff-20db-4a8b-9f1e-cb22f6a1a54f" />


## 📎 기타 참고사항
- 프로젝트 참여해도 프로젝트 홈 조회와 같은 응답을 준다고 생각해AllProjectResponseDto를 썼고 추후 조회에도 같은 dto를 쓸 생각입니다
- - modules/redis 폴더에 관련 redis 파일을 작성하여 사용하였습니다.

테스트 방법
- .env에 REDIS_URL=redis://localhost:6379 와 같이 REDIS_URL를 지정해주면 로컬에서 테스트 가능합니다
