### PR TITLE
[Refactor] userId 주입 방식 변경

### DIFF
--- a/src/common/decorators/user.decorator.ts
+++ b/src/common/decorators/user.decorator.ts
@@ -1,5 +1,11 @@
 import { createParamDecorator, ExecutionContext } from "@nestjs/common";
 
+export const User = createParamDecorator(
+    (data, ctx: ExecutionContext) => {
+        const request = ctx.switchToHttp().getRequest();
+        return data ? request.user?.[data] : request.user;
+});
+
 export const KakaoUser = createParamDecorator(
     (data: unknown, ctx: ExecutionContext) => {
         const request = ctx.switchToHttp().getRequest();

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,10 +1,10 @@
-import { Controller, Get, Req, Res, UseGuards } from "@nestjs/common";
+import { Controller, Get, Res, UseGuards } from "@nestjs/common";
 import { AuthGuard } from "@nestjs/passport";
 import { AuthService } from "./auth.service";
 import { ConfigService } from "@nestjs/config";
 import { KakaoUser, KakaoUserAfterAuth } from "src/common/decorators/user.decorator";
 import { Response } from "express";
-import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
+import { ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { Pulbic } from "src/common/decorators/public.decorator";
 
 @ApiTags('Auth')
@@ -54,14 +54,5 @@ export class AuthController{
         //TODO: 추후 refreshToken 구현 필요
         res.redirect(this.configService.get('CLIENT_REDIRECT_URI')!);    // NOTE: 환경변수 없으면 터짐!
     }
-    
-    @Get('/me')
-    @ApiBearerAuth('access-token')
-    @ApiOperation({
-        summary: '인증/인가 확인 용 임시 API',
-        description: 'accessToken에 대한 userId를 반환합니다.'
-    })
-    getMe(@Req() req) {
-        return req.user;
-    }
+
 }

--- a/src/modules/auth/strategies/jwt.strategy.ts
+++ b/src/modules/auth/strategies/jwt.strategy.ts
@@ -14,6 +14,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     }
 
     async validate(payload: any) {
-        return { userId: payload.userId };
+        return { id: payload.userId };
     }
 }

--- a/src/modules/personalRecalls/personalRecalls.controller.ts
+++ b/src/modules/personalRecalls/personalRecalls.controller.ts
@@ -1,16 +1,20 @@
 import { Controller, Get, Param } from '@nestjs/common';
 import { PersonalRecallsService } from './personalRecalls.service';
-import { ConfigService } from '@nestjs/config';
+import { User } from 'src/common/decorators/user.decorator';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 
+@ApiTags('PersonalRecalls')
+@ApiBearerAuth('access-token')
 @Controller('/projects')
 export class PersonalRecallsController {
   constructor(
     private readonly personalRecallsService: PersonalRecallsService,
-    private readonly configService: ConfigService,
   ) {}
   @Get(":projectId/personalRecalls") // 개인 회고 조회
-  async getPersonalRecalls(@Param('projectId') projectId: string) {
-    const userId = parseInt(this.configService.get('DEFAULT_USER_ID') || '1', 10); // 임시로 userId 사용
+  async getPersonalRecalls(
+    @Param('projectId') projectId: string,
+    @User('id') userId: number
+  ) {
     return await this.personalRecallsService.getPersonalRecalls(userId, +projectId);
   }
 }

--- a/src/modules/projects/projects.controller.ts
+++ b/src/modules/projects/projects.controller.ts
@@ -2,15 +2,17 @@ import { Controller, Post, Get, Patch, Body, Param, NotFoundException, Query, Fo
 import { ProjectsService } from './projects.service';
 import { CreateProjectDto, CreateProjectResponseDto } from './dto/create-project.dto';
 import { AllProjectResponseDto } from './dto/all-project-response.dto';
-import { ApiBody, ApiQuery } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { ApiCommonResponse, ApiCommonErrorResponse } from '../../common/response/swagger-responce.helper';
-import { ConfigService } from '@nestjs/config';
 import { UpdateProjectDto } from './dto/update-project.dto';
+import { User } from 'src/common/decorators/user.decorator';
+
+@ApiTags('Projects')
+@ApiBearerAuth('access-token')
 @Controller('/projects')
 export class ProjectsController {
   constructor(
     private readonly projectsService: ProjectsService,
-    private readonly configService: ConfigService
   ) {}
 
   @Post()
@@ -18,12 +20,10 @@ export class ProjectsController {
   @ApiCommonResponse(CreateProjectResponseDto)
   @ApiCommonErrorResponse('UNAUTHORIZED_USER', '인증되지 않은 사용자입니다.')   //추후에 실제 구현 필요
   async createProject(
-    @Body() dto: CreateProjectDto
-    //@ReqUser() user: UserPayload,  // 여기서 user.id를 사용
+    @Body() dto: CreateProjectDto,
+    @User('id') userId: number,
   ) {
-    const userId = parseInt(process.env.DEFAULT_USER_ID || '1', 10);
-    if (!userId) {
-      throw new NotFoundException('인증되지 않은 사용자입니다.');}
+    console.log(userId);
     return await this.projectsService.createProject(dto, userId);
   }
 
@@ -31,31 +31,32 @@ export class ProjectsController {
   @ApiQuery({ name: 'inviteCode', required: true, example: 'abcd1234' })
   @ApiCommonResponse(AllProjectResponseDto)
   @ApiCommonErrorResponse('NOT_FOUND', '유효하지 않은 초대코드입니다.',404)
-  async joinProject(@Query('inviteCode') inviteCode: string) {
-    const userId = parseInt(this.configService.get('DEFAULT_USER_ID') || '1', 10);
+  async joinProject(
+    @Query('inviteCode') inviteCode: string,
+    @User('id') userId: number,
+  ) {
+    const project = await this.projectsService.getProjectByInviteCode(inviteCode);
+    if (!project) throw new NotFoundException('유효하지 않은 초대코드입니다.');
 
-  const project = await this.projectsService.getProjectByInviteCode(inviteCode);
-  if (!project) throw new NotFoundException('유효하지 않은 초대코드입니다.');
+    const projectId = project.id;
+    const alreadyJoined = await this.projectsService.isUserInProject(userId, projectId);
+    if (!alreadyJoined) {
+      await this.projectsService.addUserToProject(userId, projectId, 'member');
+    }
 
-  const projectId = project.id;
-  const alreadyJoined = await this.projectsService.isUserInProject(userId, projectId);
-  if (!alreadyJoined) {
-    await this.projectsService.addUserToProject(userId, projectId, 'member');
+    return await this.projectsService.getProjectFullData(projectId);
   }
-
-  return await this.projectsService.getProjectFullData(projectId);
-}
 
   @Get('/:projectId')
   @ApiCommonResponse(AllProjectResponseDto)
   @ApiCommonErrorResponse('NOT_FOUND', '프로젝트를 찾을 수 없습니다.',404)
   @ApiCommonErrorResponse('FORBIDDEN', '해당 프로젝트에 접근 권한이 없습니다.',403)
-  async getProjectFullData(@Param('projectId') projectId: number) {
-
-  const userId = parseInt(process.env.DEFAULT_USER_ID || '1', 10);
-
-  const isMember = await this.projectsService.checkProjectMembership(userId, projectId);
-  if (!isMember) {
+  async getProjectFullData(
+    @Param('projectId') projectId: number,
+    @User('id') userId: number,
+  ) {
+    const isMember = await this.projectsService.checkProjectMembership(userId, projectId);
+    if (!isMember) {
       throw new ForbiddenException('해당 프로젝트에 접근 권한이 없습니다.');
     }
 
@@ -70,9 +71,8 @@ export class ProjectsController {
   async updateProject(
     @Param('projectId') projectId: number,
     @Body() dto: UpdateProjectDto,
+    @User('id') userId: number,
   ) {
-    const userId = parseInt(process.env.DEFAULT_USER_ID || '1', 10);
-
     const isMember = await this.projectsService.checkProjectMembership(userId, projectId);
     if (!isMember) {
       throw new ForbiddenException('해당 프로젝트에 접근 권한이 없습니다.');

--- a/src/modules/tasks/tasks.controller.ts
+++ b/src/modules/tasks/tasks.controller.ts
@@ -1,22 +1,24 @@
-import { Body, Controller, Post, Param, Req, UseGuards, Patch, Delete, Get} from '@nestjs/common';
+import { Body, Controller, Post, Param, Req, Patch} from '@nestjs/common';
 import { Request } from 'express';
 import { TasksService } from './tasks.service';
 import { CreateTaskRequestDto } from './dtos/create-task.dto';
-import { ConfigService } from '@nestjs/config';
-import { ApiBody } from '@nestjs/swagger';
-import { ApiCommonResponse, ApiCommonErrorResponse } from '../../common/response/swagger-responce.helper';
+import { ApiBearerAuth, ApiBody, ApiTags } from '@nestjs/swagger';
+import { ApiCommonResponse} from '../../common/response/swagger-responce.helper';
 import { UpdateTaskRequestDto , UpdateTaskResponseDto} from './dtos/update-task.dto';
-//import { JwtAuthGuard } from 'src/common/guards/jwt-auth.guard';
+import { User } from 'src/common/decorators/user.decorator';
 
+@ApiTags('Tasks')
+@ApiBearerAuth('access-token')
 @Controller('/tasks')
 export class TasksController {
-    constructor(private readonly tasksService: TasksService,
-      private readonly configService: ConfigService) {}
+  constructor(private readonly tasksService: TasksService) {}
 
   @Post()
-  //@UseGuards(JwtAuthGuard)
-  async createTask(@Req() req: Request, @Body() dto: CreateTaskRequestDto) {
-    const userId = this.configService.get('DEFAULT_USERID');
+  async createTask(
+    @Req() req: Request,
+    @Body() dto: CreateTaskRequestDto,
+    @User('id') userId: number,
+  ) {
     return await this.tasksService.createTask(userId, dto);
   } 
 
@@ -26,8 +28,9 @@ export class TasksController {
   async updateTask(
     @Param('taskId') taskId: number,
     @Req() req: Request, 
-    @Body() dto: UpdateTaskRequestDto) {
-	  const userId = this.configService.get('DEFAULT_USERID'); //하드코딩
+    @Body() dto: UpdateTaskRequestDto,
+    @User('id') userId: number,
+  ) {
 	  return await this.tasksService.updateTask(dto, userId, taskId);
-}
+  }
 }

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -1,4 +1,7 @@
 import { Controller } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 
+@ApiTags('Users')
+@ApiBearerAuth('access-token')
 @Controller('users')
 export class UsersController {}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #34 

## ✅ 작업 내용
- 기존 하드코딩된 `userId` 제거
- `@User` 데코레이터 추가
- 데코레이터로 사용자 식별 정보를 주입 받도록 코드 리팩토링
- 인증이 필요한 컨트롤러에 `@ApiBearerAuth('access-token')` 데코레이터 추가

## 📸 스크린샷
<img width="875" height="886" alt="image" src="https://github.com/user-attachments/assets/d411d518-e6ec-4448-9159-71faada3351a" />
<img width="865" height="793" alt="image" src="https://github.com/user-attachments/assets/f7acf4e1-01bd-4eaf-bb87-ab6635df0ec8" />

## 📎 기타 참고사항
- 앞으로 작업하실 때, 다음 사항들 기억해주세요!
1. 컨트롤러 상단에 `@ApiBearerAuth('access-token')` 데코레이터를 추가해주세요. 해당 데코레이터 추가해야 스웨거에서 정상적으로 테스트 가능하다고 합니다.
2. `@User` 데코레이터 사용해서 사용자 정보를 주입할 수 있습니다. 아래 예시 참고해주세요.
```ts
@Get('/example')
async exampleFunc(@User('id') userId: number){
  console.log(userId);
}
```
