### PR TITLE
[Fix] github 스크립트에 마이그레이션 런 추가, docker-compose  변경

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -54,5 +54,6 @@ jobs:
             docker image rm ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }} || true
             docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
             docker compose up -d --no-deps app
+            docker compose exec app npm run migrate:run
             docker compose logs
             docker image prune -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   app:
     image: "${DOCKER_USERNAME}/${DOCKER_REPO}:latest"
     container_name: teamie-server
+    network_mode: host
     env_file:
       - .env
     ports:

--- a/src/modules/steps/entities/steps.entity.ts
+++ b/src/modules/steps/entities/steps.entity.ts
@@ -8,9 +8,6 @@ export class Step extends BaseEntity {
     @Column({ length: 20 })
     name: string;
 
-    @Column({ default: false })
-    isDeleted: boolean;
-
     @ManyToOne(() => Project, (project) => project.steps, {
         onDelete: 'CASCADE',
     })


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #51 

## ✅ 작업 내용
- 블랙홀에 빠진 라우팅 테이블을 삭제 (Destination: 10.0.0.0/16 → Target: eni‑03459f31a2a844250 라우트는 VPC의 10.0.0.0/16대역 패킷을 특정 ENI로 끌고 가게하는데 이 ENI는 한 개의 인스턴스에만 붙어 있어서 나머지 리소스에 연결 경로가 없어서 블랙홀)
- 라우팅 테이블에 local이라는 특수 경로 (10.0.0.0/16 -> local) 추가하여 새 라우팅 테이블을 생성하여 서브넷에 연결 
  => 위 특수경로 하나로 VPC 내 모든 리소스가 서로 통신할 때 자동으로 올바른 ENI로 전달
- network_mode가 기존에는 기본 bridge 모드: 도커 브리지 -> AWS 내부 DNS 대신 외부 DNS로 질의돼 퍼블릭 IP를 받았고, AWS 헤어핀(NAT lookback)이 지원되지 않아 ETIMEDOUT 발생
  => host 모드로 변경 : 컨테이너가 호스트와 동일하게 VPC DNS를 쓰므로 바로 프라이빗 IP를 내려받고, RDS로 연결 성공
- Nest는 배포 과정 중 마이그레이션을 실행해야 함 
 => docker-compose.yml에 docker compose exec app npm run typeorm migration:run 추가


## 📸 스크린샷
![스크린샷_18-7-2025_173511_ec2-3-35-90-221 ap-northeast-2 compute amazonaws com](https://github.com/user-attachments/assets/2f04980e-8c8f-4eb9-a07f-4adecbdd45d6)


## 📎 기타 참고사항
- http://ec2-3-35-90-221.ap-northeast-2.compute.amazonaws.com:3000/docs#/ 에 접속하면 스웨거 명세 볼 수 있어요!
