### PR TITLE
[Feat] 업무 대시보드 구현

### DIFF
--- a/src/modules/tasks/dtos/get-task.dto.ts
+++ b/src/modules/tasks/dtos/get-task.dto.ts
@@ -1,8 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Status } from '../../../common/enums/status.enum';
-import { IsOptional, IsNotEmpty, IsEnum, IsArray, IsNumber } from 'class-validator';
 import { ManagerResponseDto } from '../../mappings/managers/dtos/create-manager-dto';
-import { Type } from 'class-transformer';
 import { TaskFileResponseDto } from '../../mappings/task-files/dtos/create-task-files.dto';
 import { Task } from '../tasks.entity';
 import { Manager } from '../../mappings/managers/managers.entity';

--- a/src/modules/tasks/dtos/task-dashboard-status-view-dto.ts
+++ b/src/modules/tasks/dtos/task-dashboard-status-view-dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Status } from '../../../common/enums/status.enum';
 import { ManagerResponseDto } from '../../mappings/managers/dtos/create-manager-dto';
+import { Task } from '../tasks.entity';
 
 export class TaskInStatusDto {
     @ApiProperty({
@@ -32,6 +33,19 @@ export class TaskInStatusDto {
         description: '담당자 목록',
     })
     managers: ManagerResponseDto[];
+
+    static from(task: Task): TaskInStatusDto {
+        const dto = new TaskInStatusDto();
+        dto.taskId = task.id;
+        dto.taskName = task.name;
+        dto.stepId = task.step.id;
+        dto.stepName = task.step.name;
+        dto.managers = (task.managers ?? []).map((m) => ({
+            userId: m.user.id,
+            userName: m.user.name,
+        }));
+        return dto;
+    }
 }
 
 export class StatusGroupDto {

--- a/src/modules/tasks/dtos/task-dashboard-status-view-dto.ts
+++ b/src/modules/tasks/dtos/task-dashboard-status-view-dto.ts
@@ -1,0 +1,70 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Status } from '../../../common/enums/status.enum';
+import { ManagerResponseDto } from '../../mappings/managers/dtos/create-manager-dto';
+
+export class TaskInStatusDto {
+    @ApiProperty({
+        example: 1,
+        description: '업무 ID',
+    })
+    taskId: number;
+
+    @ApiProperty({
+        example: '기능명세서 작성',
+        description: '업무명',
+    })
+    taskName: string;
+
+    @ApiProperty({
+        example: 10,
+        description: '해당 업무가 속한 단계 ID',
+    })
+    stepId: number;
+
+    @ApiProperty({
+        example: '기획',
+        description: '해당 업무가 속한 단계 이름',
+    })
+    stepName: string;
+
+    @ApiProperty({
+        type: [ManagerResponseDto],
+        description: '담당자 목록',
+    })
+    managers: ManagerResponseDto[];
+}
+
+export class StatusGroupDto {
+    @ApiProperty({
+        example: 'ONGOING',
+        enum: Status,
+        description: '진행 상황',
+    })
+    status: Status;
+
+    @ApiProperty({
+        type: [TaskInStatusDto],
+        description: '해당 상태에 속한 업무 목록',
+    })
+    tasks: TaskInStatusDto[];
+}
+
+export class TaskDashboardStatusViewDto {
+    @ApiProperty({
+        example: 1,
+        description: '프로젝트 ID',
+    })
+    projectId: number;
+
+    @ApiProperty({
+        example: '프로젝트A',
+        description: '프로젝트 이름',
+    })
+    projectName: string;
+
+    @ApiProperty({
+        type: [StatusGroupDto],
+        description: '진행 상황별로 묶인 업무 정보',
+    })
+    statusGroups: StatusGroupDto[];
+}

--- a/src/modules/tasks/dtos/task-dashboard-step-view-dto.ts
+++ b/src/modules/tasks/dtos/task-dashboard-step-view-dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Status } from '../../../common/enums/status.enum';
 import { ManagerResponseDto } from '../../mappings/managers/dtos/create-manager-dto';
+import { Task } from '../tasks.entity';
 
 export class TaskInStepDto {
     @ApiProperty({
@@ -27,6 +28,18 @@ export class TaskInStepDto {
         description: '담당자 목록',
     })
     managers: ManagerResponseDto[];
+
+    static from(task: Task): TaskInStepDto {
+        const dto = new TaskInStepDto();
+        dto.taskId = task.id;
+        dto.taskName = task.name;
+        dto.status = task.status;
+        dto.managers = (task.managers ?? []).map((m) => ({
+            userId: m.user.id,
+            userName: m.user.name,
+        }));
+        return dto;
+    }
 }
 
 export class StepGroupDto {

--- a/src/modules/tasks/dtos/task-dashboard-step-view-dto.ts
+++ b/src/modules/tasks/dtos/task-dashboard-step-view-dto.ts
@@ -1,0 +1,70 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Status } from '../../../common/enums/status.enum';
+import { ManagerResponseDto } from '../../mappings/managers/dtos/create-manager-dto';
+
+export class TaskInStepDto {
+    @ApiProperty({
+        example: 1,
+        description: '업무 ID',
+    })
+    taskId: number;
+
+    @ApiProperty({
+        example: '기능명세서 작성',
+        description: '업무명',
+    })
+    taskName: string;
+
+    @ApiProperty({
+        example: 'ONGOING',
+        enum: Status,
+        description: '진행상황',
+    })
+    status: Status;
+
+    @ApiProperty({
+        type: [ManagerResponseDto],
+        description: '담당자 목록',
+    })
+    managers: ManagerResponseDto[];
+}
+
+export class StepGroupDto {
+    @ApiProperty({
+        example: 10,
+        description: 'stepId',
+    })
+    stepId: number;
+
+    @ApiProperty({
+        example: 'step1',
+        description: '스텝 명',
+    })
+    stepName: string;
+
+    @ApiProperty({
+        type: [TaskInStepDto],
+        description: '해당 단계에 포함된 업무 목록',
+    })
+    tasks: TaskInStepDto[];
+}
+
+export class TaskDashboardStepViewDto {
+    @ApiProperty({
+        example: 1,
+        description: '프로젝트 Id',
+    })
+    projectId: number;
+
+    @ApiProperty({
+        example: '프로젝트 A',
+        description: '프로젝트명',
+    })
+    projectName: string;
+
+    @ApiProperty({
+        type: [StepGroupDto],
+        description: '단계별로 묶인 업무 정보',
+    })
+    steps: StepGroupDto[];
+}

--- a/src/modules/tasks/tasks.controller.ts
+++ b/src/modules/tasks/tasks.controller.ts
@@ -9,20 +9,12 @@ import {
     Delete,
     UploadedFiles,
     UseInterceptors,
-    Query,
+    Query
 } from '@nestjs/common';
 import { Request } from 'express';
 import { TasksService } from './tasks.service';
 import { CreateTaskRequestDto } from './dtos/create-task.dto';
-import {
-    ApiBearerAuth,
-    ApiBody,
-    ApiTags,
-    ApiQuery,
-    ApiOkResponse,
-    getSchemaPath,
-    ApiExtraModels,
-} from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiTags, ApiQuery, ApiOkResponse, getSchemaPath, ApiExtraModels } from '@nestjs/swagger';
 import { ApiCommonResponse } from '../../common/response/swagger-response.helper';
 import { UpdateTaskRequestDto, UpdateTaskResponseDto } from './dtos/update-task.dto';
 import { User } from 'src/common/decorators/user.decorator';
@@ -75,25 +67,25 @@ export class TasksController {
 
     @ApiExtraModels(TaskDashboardStepViewDto, TaskDashboardStatusViewDto)
     @ApiQuery({
-        name: 'view',
-        required: false,
-        description: '조회 방식: step 또는 status',
+    name: 'view',
+    required: false,
+    description: '조회 방식: step 또는 status',
     })
     @ApiOkResponse({
-        description: '단계별 또는 상태별로 업무를 그룹화한 대시보드 응답',
-        schema: {
-            oneOf: [
-                { $ref: getSchemaPath(TaskDashboardStepViewDto) },
-                { $ref: getSchemaPath(TaskDashboardStatusViewDto) },
-            ],
-        },
+    description: '단계별 또는 상태별로 업무를 그룹화한 대시보드 응답',
+    schema: {
+        oneOf: [
+        { $ref: getSchemaPath(TaskDashboardStepViewDto) },
+        { $ref: getSchemaPath(TaskDashboardStatusViewDto) },
+        ],
+    },
     })
     @Get('/:projectId/dashboard')
     async getTaskDashboard(
-        @Param('projectId') projectId: number,
-        @User('id') userId: number,
-        @Query('view') view: string
+    @Param('projectId') projectId: number,
+    @User('id') userId: number,
+    @Query('view') view: string,
     ): Promise<TaskDashboardStepViewDto | TaskDashboardStatusViewDto> {
-        return this.tasksService.getTaskDashBoard(userId, projectId, view);
+    return this.tasksService.getTaskDashBoard(userId, projectId, view);
     }
 }

--- a/src/modules/tasks/tasks.controller.ts
+++ b/src/modules/tasks/tasks.controller.ts
@@ -9,16 +9,27 @@ import {
     Delete,
     UploadedFiles,
     UseInterceptors,
+    Query,
 } from '@nestjs/common';
 import { Request } from 'express';
 import { TasksService } from './tasks.service';
 import { CreateTaskRequestDto } from './dtos/create-task.dto';
-import { ApiBearerAuth, ApiBody, ApiTags } from '@nestjs/swagger';
+import {
+    ApiBearerAuth,
+    ApiBody,
+    ApiTags,
+    ApiQuery,
+    ApiOkResponse,
+    getSchemaPath,
+    ApiExtraModels,
+} from '@nestjs/swagger';
 import { ApiCommonResponse } from '../../common/response/swagger-response.helper';
 import { UpdateTaskRequestDto, UpdateTaskResponseDto } from './dtos/update-task.dto';
 import { User } from 'src/common/decorators/user.decorator';
 import { FilesInterceptor } from '@nestjs/platform-express';
 import { GetTaskResponseDto } from './dtos/get-task.dto';
+import { TaskDashboardStepViewDto } from './dtos/task-dashboard-step-view-dto';
+import { TaskDashboardStatusViewDto } from './dtos/task-dashboard-status-view-dto';
 
 @ApiTags('Tasks')
 @ApiBearerAuth('access-token')
@@ -60,5 +71,29 @@ export class TasksController {
     @ApiCommonResponse(GetTaskResponseDto)
     async getTask(@Param('taskId') taskId: number, @User('id') userId: number) {
         return await this.tasksService.getTask(userId, taskId);
+    }
+
+    @ApiExtraModels(TaskDashboardStepViewDto, TaskDashboardStatusViewDto)
+    @ApiQuery({
+        name: 'view',
+        required: false,
+        description: '조회 방식: step 또는 status',
+    })
+    @ApiOkResponse({
+        description: '단계별 또는 상태별로 업무를 그룹화한 대시보드 응답',
+        schema: {
+            oneOf: [
+                { $ref: getSchemaPath(TaskDashboardStepViewDto) },
+                { $ref: getSchemaPath(TaskDashboardStatusViewDto) },
+            ],
+        },
+    })
+    @Get('/:projectId/dashboard')
+    async getTaskDashboard(
+        @Param('projectId') projectId: number,
+        @User('id') userId: number,
+        @Query('view') view: string
+    ): Promise<TaskDashboardStepViewDto | TaskDashboardStatusViewDto> {
+        return this.tasksService.getTaskDashBoard(userId, projectId, view);
     }
 }

--- a/src/modules/tasks/tasks.controller.ts
+++ b/src/modules/tasks/tasks.controller.ts
@@ -14,7 +14,7 @@ import {
 import { Request } from 'express';
 import { TasksService } from './tasks.service';
 import { CreateTaskRequestDto } from './dtos/create-task.dto';
-import { ApiBearerAuth, ApiBody, ApiTags, ApiQuery, ApiOkResponse, getSchemaPath, ApiExtraModels } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiTags, ApiQuery, ApiOkResponse, ApiOperation, getSchemaPath, ApiExtraModels } from '@nestjs/swagger';
 import { ApiCommonResponse } from '../../common/response/swagger-response.helper';
 import { UpdateTaskRequestDto, UpdateTaskResponseDto } from './dtos/update-task.dto';
 import { User } from 'src/common/decorators/user.decorator';
@@ -71,6 +71,10 @@ export class TasksController {
     required: false,
     description: '조회 방식: step 또는 status',
     })
+    @ApiOperation({
+    summary: '업무 대시보드',
+	  description: '프로젝트 별 업무 대시보드입니다.'
+})
     @ApiOkResponse({
     description: '단계별 또는 상태별로 업무를 그룹화한 대시보드 응답',
     schema: {

--- a/src/modules/tasks/tasks.module.ts
+++ b/src/modules/tasks/tasks.module.ts
@@ -9,9 +9,13 @@ import { ConfigModule } from '@nestjs/config';
 import { Manager } from '../mappings/managers/managers.entity';
 import { TaskFile } from '../mappings/task-files/task-files.entity';
 import { UploadService } from '../../infra/upload/upload.service';
+import { Project } from '../projects/entities/projects.entity';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([Task, Step, UserProject, Manager, TaskFile]), ConfigModule],
+    imports: [
+        TypeOrmModule.forFeature([Task, Step, UserProject, Manager, TaskFile, Project]),
+        ConfigModule,
+    ],
     controllers: [TasksController],
     providers: [TasksService, UploadService],
 })

--- a/src/modules/tasks/tasks.service.ts
+++ b/src/modules/tasks/tasks.service.ts
@@ -7,14 +7,21 @@ import { UserProject } from '../mappings/user-projects/userProjects.entity';
 import { CreateTaskRequestDto, CreateTaskResponseDto } from './dtos/create-task.dto';
 import { UpdateTaskRequestDto, UpdateTaskResponseDto } from './dtos/update-task.dto';
 import { Manager } from '../mappings/managers/managers.entity';
+import { Project } from '../projects/entities/projects.entity';
 import { DeleteTaskResponseDto } from './dtos/delete-task.dto';
 import { TaskFile } from '../mappings/task-files/task-files.entity';
 import { GetTaskResponseDto } from './dtos/get-task.dto';
 import { UploadService } from '../../infra/upload/upload.service';
+import { TaskDashboardStepViewDto } from './dtos/task-dashboard-step-view-dto';
+import { TaskDashboardStatusViewDto } from './dtos/task-dashboard-status-view-dto';
+import { StepGroupDto, TaskInStepDto } from './dtos/task-dashboard-step-view-dto';
+import { StatusGroupDto, TaskInStatusDto } from './dtos/task-dashboard-status-view-dto';
+import { Status } from '../../common/enums/status.enum';
 import {
     ProjectForbiddenException,
     StepNotFoundException,
     TaskNotFoundException,
+    ProjectNotFoundException,
 } from 'src/common/exceptions/custom.errors';
 
 @Injectable()
@@ -25,6 +32,9 @@ export class TasksService {
 
         @InjectRepository(Step)
         private readonly stepRepository: Repository<Step>,
+
+        @InjectRepository(Project)
+        private readonly projectRepository: Repository<Project>,
 
         @InjectRepository(UserProject)
         private readonly userProjectRepository: Repository<UserProject>,
@@ -261,5 +271,106 @@ export class TasksService {
         const managers = task.managers;
 
         return GetTaskResponseDto.from(task, managers);
+    }
+
+    async getTaskDashBoard(
+        userId: number,
+        projectId: number,
+        view: string
+    ): Promise<TaskDashboardStepViewDto | TaskDashboardStatusViewDto> {
+        // 1. 프로젝트 존재 및 참여자 검증
+        const project = await this.projectRepository.findOne({
+            where: { id: projectId },
+            relations: ['userProjects'],
+        });
+
+        if (!project) throw new ProjectNotFoundException();
+
+        const isMember = await this.userProjectRepository.findOne({
+            where: { user: { id: userId }, project: { id: projectId } },
+        });
+
+        if (!isMember) throw new ProjectForbiddenException();
+
+        // 2. 프로젝트 전체 업무 조회 (step 포함)
+        const tasks = await this.taskRepository.find({
+            where: { step: { project: { id: projectId } } },
+            relations: ['step', 'managers', 'managers.user'],
+        });
+
+        // 3. view 값에 따라 응답 구조 조립
+        if (view === 'status') {
+            const statusGroups = this.groupByStatus(tasks);
+            return {
+                projectId: project.id,
+                projectName: project.name,
+                statusGroups,
+            };
+        } else {
+            const stepGroups = this.groupByStep(tasks);
+            return {
+                projectId: project.id,
+                projectName: project.name,
+                steps: stepGroups,
+            };
+        }
+    }
+
+    private groupByStep(tasks: Task[]): StepGroupDto[] {
+        const map = new Map<number, StepGroupDto>();
+
+        for (const task of tasks) {
+            const stepId = task.step.id;
+            if (!map.has(stepId)) {
+                map.set(stepId, {
+                    stepId,
+                    stepName: task.step.name,
+                    tasks: [],
+                });
+            }
+
+            const taskDto: TaskInStepDto = {
+                taskId: task.id,
+                taskName: task.name,
+                status: task.status,
+                managers: task.managers.map((m) => ({
+                    userId: m.user.id,
+                    userName: m.user.name,
+                })),
+            };
+
+            map.get(stepId)!.tasks.push(taskDto);
+        }
+
+        return [...map.values()];
+    }
+
+    private groupByStatus(tasks: Task[]): StatusGroupDto[] {
+        const map = new Map<Status, StatusGroupDto>();
+
+        for (const task of tasks) {
+            const status = task.status;
+            if (!map.has(status)) {
+                map.set(status, {
+                    status,
+                    tasks: [],
+                });
+            }
+
+            const taskDto: TaskInStatusDto = {
+                taskId: task.id,
+                taskName: task.name,
+                stepId: task.step.id,
+                stepName: task.step.name,
+                managers: task.managers.map((m) => ({
+                    userId: m.user.id,
+                    userName: m.user.name,
+                })),
+            };
+
+            map.get(status)!.tasks.push(taskDto);
+        }
+
+        return [...map.values()];
     }
 }

--- a/src/modules/tasks/tasks.service.ts
+++ b/src/modules/tasks/tasks.service.ts
@@ -293,10 +293,14 @@ export class TasksService {
         if (!isMember) throw new ProjectForbiddenException();
 
         // 2. 프로젝트 전체 업무 조회 (step 포함)
-        const tasks = await this.taskRepository.find({
-            where: { step: { project: { id: projectId } } },
-            relations: ['step', 'managers', 'managers.user'],
-        });
+        const tasks = await this.taskRepository
+            .createQueryBuilder('task')
+            .leftJoinAndSelect('task.step', 'step')
+            .leftJoin('task.managers', 'manager')
+            .leftJoin('manager.user', 'user')
+            .addSelect(['user.id', 'user.name']) 
+            .where('step.projectId = :projectId', { projectId })
+            .getMany();
 
         // 3. view 값에 따라 응답 구조 조립
         if (view === 'status') {
@@ -333,7 +337,7 @@ export class TasksService {
                 taskId: task.id,
                 taskName: task.name,
                 status: task.status,
-                managers: task.managers.map((m) => ({
+                managers: (task.managers ?? []).map((m) => ({
                     userId: m.user.id,
                     userName: m.user.name,
                 })),
@@ -362,7 +366,7 @@ export class TasksService {
                 taskName: task.name,
                 stepId: task.step.id,
                 stepName: task.step.name,
-                managers: task.managers.map((m) => ({
+                managers: (task.managers ?? []).map((m) => ({
                     userId: m.user.id,
                     userName: m.user.name,
                 })),

--- a/src/modules/tasks/tasks.service.ts
+++ b/src/modules/tasks/tasks.service.ts
@@ -22,6 +22,7 @@ import {
     StepNotFoundException,
     TaskNotFoundException,
     ProjectNotFoundException,
+    BadRequestException
 } from 'src/common/exceptions/custom.errors';
 
 @Injectable()
@@ -278,6 +279,9 @@ export class TasksService {
         projectId: number,
         view: string
     ): Promise<TaskDashboardStepViewDto | TaskDashboardStatusViewDto> {
+        if (view !== 'step' && view !== 'status') {
+            throw new BadRequestException(`'view' 파라미터는 'step' 또는 'status'만 허용됩니다.`);
+}
         // 1. 프로젝트 존재 및 참여자 검증
         const project = await this.projectRepository.findOne({
             where: { id: projectId },
@@ -298,7 +302,7 @@ export class TasksService {
             .leftJoinAndSelect('task.step', 'step')
             .leftJoin('task.managers', 'manager')
             .leftJoin('manager.user', 'user')
-            .addSelect(['user.id', 'user.name']) 
+            .addSelect(['user.id', 'user.name'])
             .where('step.projectId = :projectId', { projectId })
             .getMany();
 
@@ -333,19 +337,9 @@ export class TasksService {
                 });
             }
 
-            const taskDto: TaskInStepDto = {
-                taskId: task.id,
-                taskName: task.name,
-                status: task.status,
-                managers: (task.managers ?? []).map((m) => ({
-                    userId: m.user.id,
-                    userName: m.user.name,
-                })),
-            };
-
+            const taskDto = TaskInStepDto.from(task);
             map.get(stepId)!.tasks.push(taskDto);
         }
-
         return [...map.values()];
     }
 
@@ -361,17 +355,7 @@ export class TasksService {
                 });
             }
 
-            const taskDto: TaskInStatusDto = {
-                taskId: task.id,
-                taskName: task.name,
-                stepId: task.step.id,
-                stepName: task.step.name,
-                managers: (task.managers ?? []).map((m) => ({
-                    userId: m.user.id,
-                    userName: m.user.name,
-                })),
-            };
-
+            const taskDto = TaskInStatusDto.from(task);
             map.get(status)!.tasks.push(taskDto);
         }
 


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #72

## ✅ 작업 내용

- 대시보드 API 엔드포인트 구현
    - GET /projects/:projectId/dashboard?view=step|status
    - view 값에 따라 응답 형식 분기 처리
- 업무 그룹핑 로직 추가
    - groupByStep(): 동일 STEP에 속한 업무를 그룹화 
    - groupByStatus(): 동일 진행 상태에 속한 업무를 그룹화
- 응답 DTO 분리 및 Swagger 문서화
    - TaskDashboardStepViewDto, TaskDashboardStatusViewDto로 view별 구조 명확히 분리 
    - @ApiOkResponse({ oneOf: [...] })를 사용해 Swagger에서 조건부 응답 구조 표시

## 📸 스크린샷

-  step
<img width="1196" height="815" alt="대시보드 스텝별" src="https://github.com/user-attachments/assets/d6b54c7f-88bb-4941-bd02-fd1f4061cbd0" />

- status
<img width="1346" height="752" alt="대시보드 진행상황별" src="https://github.com/user-attachments/assets/8eac05bb-bc97-4cb0-acb5-073e251590ff" />

- 실패시
<img width="675" height="389" alt="대시보드실패" src="https://github.com/user-attachments/assets/fc4a9a11-0f47-4b48-bcee-5ee3bbaec7a9" />


## 📎 기타 참고사항
Swagger 문서화 관련
- `GET /projects/:projectId/dashboard` 대시보드 API의 Swagger 문서화에서
기존에 사용 중이던 `@ApiCommonResponse(CommonResponse<T>)`를 활용하지 않고
`@ApiOkResponse({ schema: { oneOf: [...] } })` 방식으로 작성하였습니다.

- 이유
    - 공통 응답 구조(`CommonResponse`)를 그대로 사용하면서 Swagger에 `oneOf` 타입을 명확히 표현하려면
  `@ApiCommonResponse()` 데코레이터를 커스터마이징해야 했는데
    - 커스터마이징 도중 `typeof DTO | typeof DTO` 타입 배열 관련 타입 추론 오류(Type inference 문제)가 발생하여 (`@ApiOkResponse`)으로 처리하였습니다.

기능 동작과 응답 포맷에는 영향이 없긴합니다..!
추후 필요시 `@ApiCommonResponse()`를 보완하여 재적용할 수 있습니다.

혹시 Swagger 문서 구조나 방식에 문제가 있다면 코멘트 부탁드립니다!