### PR TITLE
[Refactor] 개인 회고 컬럼명 수정 및 글자 수 수정

### DIFF
--- a/src/modules/personal-recalls/dtos/personal-recall-response.dto.ts
+++ b/src/modules/personal-recalls/dtos/personal-recall-response.dto.ts
@@ -5,24 +5,28 @@ export class PersonalRecallResponseDto {
         example: '내가 가장 잘했다고 생각하는 건 ‘전체 흐름을 잡아가는 능력’이었다...',
         description: '질문1에 대한 답변',
     })
-    Q1: string;
+    collaborationProfile: string;
     @ApiProperty({
         example:
             '6월 정기모임 참석률이 예상보다 낮았던 날, 준비한 조별 활동이 어색해져 현장에서 급히 프로그램을 수정해야 했다...',
         description: '질문2에 대한 답변',
     })
-    Q2: string;
+    memorableExperience: string;
     @ApiProperty({
         example: '강점은 ‘관계의 리듬을 설계하는 감각’과 ‘사람 중심 운영’이다...',
         description: '질문3에 대한 답변',
     })
-    Q3: string;
+    strengthsAndGrowth: string;
 
-    static from(entity: { Q1: string; Q2: string; Q3: string }): PersonalRecallResponseDto {
+    static from(entity: {
+        collaborationProfile: string;
+        memorableExperience: string;
+        strengthsAndGrowth: string;
+    }): PersonalRecallResponseDto {
         const dto = new PersonalRecallResponseDto();
-        dto.Q1 = entity.Q1;
-        dto.Q2 = entity.Q2;
-        dto.Q3 = entity.Q3;
+        dto.collaborationProfile = entity.collaborationProfile;
+        dto.memorableExperience = entity.memorableExperience;
+        dto.strengthsAndGrowth = entity.strengthsAndGrowth;
         return dto;
     }
 }

--- a/src/modules/personal-recalls/dtos/update-personal-recall.dto.ts
+++ b/src/modules/personal-recalls/dtos/update-personal-recall.dto.ts
@@ -5,16 +5,16 @@ export class UpdatePersonalRecallDto {
         example: '내가 가장 잘했다고 생각하는 건 ‘전체 흐름을 잡아가는 능력’이었다...',
         description: '질문1에 대한 답변',
     })
-    Q1?: string;
+    collaborationProfile?: string;
     @ApiPropertyOptional({
         example:
             '6월 정기모임 참석률이 예상보다 낮았던 날, 준비한 조별 활동이 어색해져 현장에서 급히 프로그램을 수정해야 했다...',
         description: '질문2에 대한 답변',
     })
-    Q2?: string;
+    memorableExperience?: string;
     @ApiPropertyOptional({
         example: '강점은 ‘관계의 리듬을 설계하는 감각’과 ‘사람 중심 운영’이다...',
         description: '질문3에 대한 답변',
     })
-    Q3?: string;
+    strengthsAndGrowth?: string;
 }

--- a/src/modules/personal-recalls/entities/personal-recalls.entity.ts
+++ b/src/modules/personal-recalls/entities/personal-recalls.entity.ts
@@ -5,14 +5,14 @@ import { Project } from '../../projects/entities/projects.entity';
 
 @Entity()
 export class PersonalRecall extends BaseEntity {
-    @Column({ length: 5000 })
-    Q1: string;
+    @Column({ length: 2000, nullable: true })
+    collaborationProfile: string;
 
-    @Column({ length: 5000 })
-    Q2: string;
+    @Column({ length: 2000, nullable: true })
+    memorableExperience: string;
 
-    @Column({ length: 5000 })
-    Q3: string;
+    @Column({ length: 2000, nullable: true })
+    strengthsAndGrowth: string;
 
     @ManyToOne(() => User, (user) => user.personalRecalls, {
         onDelete: 'CASCADE',

--- a/src/modules/personal-recalls/personal-recalls.controller.ts
+++ b/src/modules/personal-recalls/personal-recalls.controller.ts
@@ -21,7 +21,7 @@ export class PersonalRecallsController {
         summary: '개인 회고 조회',
         description: '프로젝트에 대한 개인 회고를 조회합니다.',
     })
-    @Get(':projectId/personalRecalls') // 개인 회고 조회
+    @Get(':projectId/personal-recalls') // 개인 회고 조회
     async getPersonalRecalls(
         @Param('projectId', ParseIntPipe) projectId: number,
         @User('id') userId: number
@@ -36,7 +36,7 @@ export class PersonalRecallsController {
         summary: '개인 회고 수정',
         description: '프로젝트에 대한 개인 회고를 수정합니다.',
     })
-    @Patch(':projectId/personalRecalls') // 개인 회고 수정
+    @Patch(':projectId/personal-recalls') // 개인 회고 수정
     async updatePersonalRecalls(
         @Param('projectId', ParseIntPipe) projectId: number,
         @User('id') userId: number,

--- a/src/modules/tasks/tasks.controller.ts
+++ b/src/modules/tasks/tasks.controller.ts
@@ -9,12 +9,21 @@ import {
     Delete,
     UploadedFiles,
     UseInterceptors,
-    Query
+    Query,
 } from '@nestjs/common';
 import { Request } from 'express';
 import { TasksService } from './tasks.service';
 import { CreateTaskRequestDto } from './dtos/create-task.dto';
-import { ApiBearerAuth, ApiBody, ApiTags, ApiQuery, ApiOkResponse, ApiOperation, getSchemaPath, ApiExtraModels } from '@nestjs/swagger';
+import {
+    ApiBearerAuth,
+    ApiBody,
+    ApiTags,
+    ApiQuery,
+    ApiOkResponse,
+    ApiOperation,
+    getSchemaPath,
+    ApiExtraModels,
+} from '@nestjs/swagger';
 import { ApiCommonResponse } from '../../common/response/swagger-response.helper';
 import { UpdateTaskRequestDto, UpdateTaskResponseDto } from './dtos/update-task.dto';
 import { User } from 'src/common/decorators/user.decorator';
@@ -67,29 +76,29 @@ export class TasksController {
 
     @ApiExtraModels(TaskDashboardStepViewDto, TaskDashboardStatusViewDto)
     @ApiQuery({
-    name: 'view',
-    required: false,
-    description: '조회 방식: step 또는 status',
+        name: 'view',
+        required: false,
+        description: '조회 방식: step 또는 status',
     })
     @ApiOperation({
-    summary: '업무 대시보드',
-	  description: '프로젝트 별 업무 대시보드입니다.'
-})
+        summary: '업무 대시보드',
+        description: '프로젝트 별 업무 대시보드입니다.',
+    })
     @ApiOkResponse({
-    description: '단계별 또는 상태별로 업무를 그룹화한 대시보드 응답',
-    schema: {
-        oneOf: [
-        { $ref: getSchemaPath(TaskDashboardStepViewDto) },
-        { $ref: getSchemaPath(TaskDashboardStatusViewDto) },
-        ],
-    },
+        description: '단계별 또는 상태별로 업무를 그룹화한 대시보드 응답',
+        schema: {
+            oneOf: [
+                { $ref: getSchemaPath(TaskDashboardStepViewDto) },
+                { $ref: getSchemaPath(TaskDashboardStatusViewDto) },
+            ],
+        },
     })
     @Get('/:projectId/dashboard')
     async getTaskDashboard(
-    @Param('projectId') projectId: number,
-    @User('id') userId: number,
-    @Query('view') view: string,
+        @Param('projectId') projectId: number,
+        @User('id') userId: number,
+        @Query('view') view: string
     ): Promise<TaskDashboardStepViewDto | TaskDashboardStatusViewDto> {
-    return this.tasksService.getTaskDashBoard(userId, projectId, view);
+        return this.tasksService.getTaskDashBoard(userId, projectId, view);
     }
 }

--- a/src/modules/tasks/tasks.service.ts
+++ b/src/modules/tasks/tasks.service.ts
@@ -22,7 +22,7 @@ import {
     StepNotFoundException,
     TaskNotFoundException,
     ProjectNotFoundException,
-    BadRequestException
+    BadRequestException,
 } from 'src/common/exceptions/custom.errors';
 
 @Injectable()
@@ -281,7 +281,7 @@ export class TasksService {
     ): Promise<TaskDashboardStepViewDto | TaskDashboardStatusViewDto> {
         if (view !== 'step' && view !== 'status') {
             throw new BadRequestException(`'view' 파라미터는 'step' 또는 'status'만 허용됩니다.`);
-}
+        }
         // 1. 프로젝트 존재 및 참여자 검증
         const project = await this.projectRepository.findOne({
             where: { id: projectId },


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #80 

## ✅ 작업 내용

- 컬럼명 구체적으로 변경 (`collaborationProfile`, `memorableExperience`, `strengthsAndGrowth`)
- 글자 수 5000자에서 2000자로 수정
- 입력 컬럼의 nullable을 true로 설정
- Endpoint를 `personal-recalls`로 수정

## 📸 스크린샷

<img width="455" height="532" alt="image" src="https://github.com/user-attachments/assets/dd52f845-7613-4540-bec8-4ccc951926c6" />


## 📎 기타 참고사항
