### PR TITLE
[Feat] step 수정 구현

### DIFF
--- a/src/modules/steps/dtos/create-step.dto.ts
+++ b/src/modules/steps/dtos/create-step.dto.ts
@@ -10,13 +10,6 @@ export class CreateStepDto {
     })
     @IsNotEmpty()
     name: string;
-
-    @ApiProperty({
-        example: 1,
-        description: '프로젝트 ID',
-    })
-    @IsNotEmpty()
-    projectId: number;
 }
 
 export class CreateStepResponseDto {

--- a/src/modules/steps/dtos/update-step.dto.ts
+++ b/src/modules/steps/dtos/update-step.dto.ts
@@ -1,0 +1,24 @@
+import { IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+export class UpdateStepDto {
+    @ApiProperty({
+        example: '기획 단계',
+        description: '수정할 Step의 이름',
+    })
+    @IsNotEmpty({ message: '스텝 이름을 반드시 입력해야 합니다.' })
+    name: string;
+}
+export class UpdateStepResponseDto {
+    @ApiProperty({ example: 1, description: '수정된 Step ID' })
+    stepId: number;
+
+    @ApiProperty({ example: '기획 단계', description: '수정된 Step의 이름' })
+    name: string;
+
+    static fromEntity(dto: UpdateStepDto, stepId: number): UpdateStepResponseDto {
+        const responseDto = new UpdateStepResponseDto();
+        responseDto.stepId = stepId;
+        responseDto.name = dto.name;
+        return responseDto;
+    }
+}

--- a/src/modules/steps/steps.controller.ts
+++ b/src/modules/steps/steps.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import { Controller, Body, ParseIntPipe, Patch, Param } from '@nestjs/common';
 import { StepsService } from './steps.service';
 import { ApiBearerAuth, ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
 import {
@@ -7,9 +7,28 @@ import {
 } from '../../common/response/swagger-response.helper';
 import { CreateStepDto } from './dtos/create-step.dto';
 import { User } from 'src/common/decorators/user.decorator';
+import { CommonResponse } from 'src/common/response/common-response.dto';
+import { UpdateStepDto, UpdateStepResponseDto } from './dtos/update-step.dto';
+
 @ApiTags('Steps')
 @ApiBearerAuth('access-token')
 @Controller('/steps')
 export class StepsController {
     constructor(private readonly stepsService: StepsService) {}
+    @Patch('/:stepId')
+    @ApiOperation({
+        summary: 'step 수정',
+        description: 'step의 이름을 수정합니다.',
+    })
+    @ApiBody({ type: UpdateStepDto })
+    @ApiCommonResponse(UpdateStepResponseDto)
+    @ApiCommonErrorResponse('STEP_NOT_FOUND', '해당 Step을 찾을 수 없습니다.')
+    @ApiCommonErrorResponse('UNAUTHORIZED_USER', '인증되지 않은 사용자입니다.')
+    async updateStep(
+        @Param('stepId', ParseIntPipe) stepId: number,
+        @Body() dto: UpdateStepDto,
+        @User() userId: number
+    ): Promise<CommonResponse<UpdateStepDto>> {
+        return this.stepsService.updateStep(stepId, dto, userId);
+    }
 }

--- a/src/modules/steps/steps.service.ts
+++ b/src/modules/steps/steps.service.ts
@@ -9,24 +9,23 @@ import { Cache } from 'cache-manager';
 import { ConfigService } from '@nestjs/config';
 import { CommonResponse } from '../../common/response/common-response.dto';
 import { ProjectNotFoundException } from 'src/common/exceptions/custom.errors';
+import { UpdateStepDto, UpdateStepResponseDto } from './dtos/update-step.dto';
+import { StepNotFoundException } from '../../common/exceptions/custom.errors';
+
 @Injectable()
 export class StepsService {
     constructor(
         @InjectRepository(Step)
         private readonly stepRepository: Repository<Step>,
         @InjectRepository(Project)
-        private readonly projectRepository: Repository<Project>,
-        @Inject('REDIS_CLIENT')
-        private readonly redis: Cache,
-        private readonly configService: ConfigService
+        private readonly projectRepository: Repository<Project>
     ) {}
 
     async createStep(
         dto: CreateStepDto,
-        proejectId: Number,
-        userId: number
+        projectId: number
     ): Promise<CommonResponse<StepWithTaskDto>> {
-        const { name, projectId } = dto;
+        const { name } = dto;
 
         const project = await this.projectRepository.findOne({ where: { id: projectId } });
         if (!project) {
@@ -35,11 +34,27 @@ export class StepsService {
 
         const step = this.stepRepository.create({
             name,
-            project,
+            project: { id: projectId },
         });
 
         const savedStep = await this.stepRepository.save(step);
 
         return CommonResponse.success(StepWithTaskDto.fromEntity(savedStep));
+    }
+
+    async updateStep(
+        stepId: number,
+        dto: UpdateStepDto,
+        userId: number
+    ): Promise<CommonResponse<UpdateStepResponseDto>> {
+        const step = await this.stepRepository.findOne({ where: { id: stepId } });
+        if (!step) {
+            throw new StepNotFoundException();
+        }
+
+        step.name = dto.name;
+        const updatedStep = await this.stepRepository.save(step);
+
+        return CommonResponse.success(UpdateStepResponseDto.fromEntity(updatedStep, stepId));
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #77 

## ✅ 작업 내용

- step 수정 api 구현
- 추가로, step 생성할 때 요청, 응답 dto를 좀 더 간소화했습니다

## 📸 스크린샷

![스크린샷_22-7-2025_20399_localhost](https://github.com/user-attachments/assets/072900ea-a4f5-4208-a3d1-02b0da65801e)

생성된 step의 이름 수정

![스크린샷_22-7-2025_204038_localhost](https://github.com/user-attachments/assets/3bf7c8fa-171f-4f1a-8318-3788b658b106)


## 📎 기타 참고사항
- 예전에 메서드를 만들어서 완료된 프로젝트면 프로젝트 필드가 수정이 안되게 만들었는데, 생각해보니 댓글이나 스텝 생성, 수정, 업무 생성 수정등등도 막아야 할 것 같은데 추후에 메서드를 없애고 Guard를 만들어서 다 막도록 하겠습니다
