### PR TITLE
[Docs] MasterPortfolio API 엔드포인트에 Swagger 명세 추가

### DIFF
--- a/src/common/response/swagger-response.helper.ts
+++ b/src/common/response/swagger-response.helper.ts
@@ -24,6 +24,30 @@ export const ApiCommonResponse = <T extends Type<any>>(model: T) => {
     );
 };
 
+export const ApiCommonResponseArray = <T extends Type<any>>(model: T) => {
+    return applyDecorators(
+        ApiExtraModels(CommonResponse, model),
+        ApiOkResponse({
+            description: '성공 응답',
+            schema: {
+                allOf: [
+                    { $ref: getSchemaPath(CommonResponse) },
+                    {
+                        properties: {
+                            isSuccess: { type: 'boolean', example: true },
+                            error: { type: 'null', example: null },
+                            result: {
+                                type: 'array',
+                                items: { $ref: getSchemaPath(model) },
+                            },
+                        },
+                    },
+                ],
+            },
+        })
+    );
+};
+
 export const ApiCommonResponseWithPagination = <T extends Type<any>>(model: T) => {
     return applyDecorators(
         ApiExtraModels(CommonResponse, PaginatedResponseDto, PageInfoDto, model),

--- a/src/modules/master-portfolios/dtos/master-portfolio-request.dto.ts
+++ b/src/modules/master-portfolios/dtos/master-portfolio-request.dto.ts
@@ -1,11 +1,41 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { portfolioType } from 'src/common/enums/portfolio-type.enum';
 
 export class MasterPortfolioRequestDto {
+    @ApiProperty({
+        example: '프로젝트에 대한 상세 정보입니다.',
+        description: '프로젝트에 대한 상세 정보',
+    })
     detailInfo?: string;
+    @ApiProperty({
+        example: '프로젝트에서 담당한 업무입니다.',
+        description: '프로젝트에서 담당한 업무',
+    })
     assignedTask?: string;
+    @ApiProperty({
+        example: '프로젝트에서 달성한 주요 성과입니다.',
+        description: '프로젝트에서 달성한 주요 성과',
+    })
     keyAchievement?: string;
+    @ApiProperty({
+        example: '프로젝트에서 배운 점입니다.',
+        description: '프로젝트에서 배운 점',
+    })
     insight?: string;
+    @ApiProperty({
+        example: 50,
+        description: '프로젝트에 대한 기여도 (0-100)',
+    })
     contributionRate?: number;
+    @ApiProperty({
+        example: '자료조사, 정리',
+        description: '프로젝트의 주요 업무',
+    })
     mainTask?: string;
+    @ApiProperty({
+        example: portfolioType.OTHER,
+        description: '포트폴리오 유형',
+        enum: portfolioType,
+    })
     category?: portfolioType;
 }

--- a/src/modules/master-portfolios/dtos/master-portfolio-response.dto.ts
+++ b/src/modules/master-portfolios/dtos/master-portfolio-response.dto.ts
@@ -1,14 +1,48 @@
 import { portfolioType } from 'src/common/enums/portfolio-type.enum';
 import { MasterPortfolio } from '../entities/master-portfolios.entity';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class MasterPortfolioResponseDto {
+    @ApiProperty({
+        description: '마스터 포트폴리오 ID',
+        example: 1,
+    })
     id: number;
+    @ApiProperty({
+        description: '프로젝트에 대한 상세 정보',
+        example: '프로젝트에 대한 상세 정보입니다.',
+    })
     detailInfo: string;
+    @ApiProperty({
+        description: '프로젝트에서 담당한 업무',
+        example: '프로젝트에서 담당한 업무입니다.',
+    })
     assignedTask: string;
+    @ApiProperty({
+        description: '프로젝트에서 달성한 주요 성과',
+        example: '프로젝트에서 달성한 주요 성과입니다.',
+    })
     keyAchievement: string;
+    @ApiProperty({
+        description: '프로젝트에서 배운 점',
+        example: '프로젝트에서 배운 점입니다.',
+    })
     insight: string;
+    @ApiProperty({
+        description: '프로젝트에 대한 기여도 (0-100)',
+        example: 50,
+    })
     contributionRate: number;
+    @ApiProperty({
+        description: '프로젝트의 주요 업무',
+        example: '자료조사, 정리',
+    })
     mainTask: string;
+    @ApiProperty({
+        description: '포트폴리오 유형',
+        example: portfolioType.OTHER,
+        enum: portfolioType,
+    })
     category: portfolioType;
 
     static from(data: MasterPortfolio): MasterPortfolioResponseDto {

--- a/src/modules/master-portfolios/master-portfolios.controller.ts
+++ b/src/modules/master-portfolios/master-portfolios.controller.ts
@@ -1,13 +1,6 @@
 import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Query } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import {
-    ApiBearerAuth,
-    ApiBody,
-    ApiOperation,
-    ApiParam,
-    ApiProperty,
-    ApiTags,
-} from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 import { PaginatedResponseDto } from 'src/common/response/paginated-response.dto';
 import {
     Cursor,
@@ -41,6 +34,11 @@ export class MasterPortfoliosController {
     })
     @ApiParam({ name: 'projectId', type: Number, description: '프로젝트 ID' })
     @ApiCommonResponseArray(QuestionResponseDto)
+    @ApiCommonErrorResponse(
+        'MASTER_PORTFOLIO_NOT_FOUND',
+        '마스터 포트폴리오를 찾을 수 없습니다.',
+        404
+    )
     async createQuestions(
         @Param('projectId', ParseIntPipe) projectId: number,
         @User('id') userId: number
@@ -55,6 +53,11 @@ export class MasterPortfoliosController {
     })
     @ApiParam({ name: 'projectId', type: Number, description: '프로젝트 ID' })
     @ApiCommonResponse(MasterPortfolioResponseDto)
+    @ApiCommonErrorResponse(
+        'MASTER_PORTFOLIO_NOT_FOUND',
+        '마스터 포트폴리오를 찾을 수 없습니다.',
+        404
+    )
     async generateMasterPortfolio(
         @Param('projectId', ParseIntPipe) projectId: number,
         @User('id') userId: number

--- a/src/modules/master-portfolios/master-portfolios.controller.ts
+++ b/src/modules/master-portfolios/master-portfolios.controller.ts
@@ -1,6 +1,13 @@
 import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Query } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { ApiBearerAuth, ApiOperation, ApiProperty, ApiTags } from '@nestjs/swagger';
+import {
+    ApiBearerAuth,
+    ApiBody,
+    ApiOperation,
+    ApiParam,
+    ApiProperty,
+    ApiTags,
+} from '@nestjs/swagger';
 import { PaginatedResponseDto } from 'src/common/response/paginated-response.dto';
 import {
     Cursor,
@@ -9,7 +16,14 @@ import {
 import { MasterPortfoliosService } from './master-portfolios.service';
 import { User } from 'src/common/decorators/user.decorator';
 import { MasterPortfolioRequestDto } from './dtos/master-portfolio-request.dto';
-import { ApiCommonResponseWithPagination } from 'src/common/response/swagger-response.helper';
+import {
+    ApiCommonErrorResponse,
+    ApiCommonResponse,
+    ApiCommonResponseArray,
+    ApiCommonResponseWithPagination,
+} from 'src/common/response/swagger-response.helper';
+import { QuestionResponseDto } from './dtos/question-response.dto';
+import { MasterPortfolioResponseDto } from './dtos/master-portfolio-response.dto';
 
 @ApiTags('MasterPortfolios')
 @ApiBearerAuth('access-token')
@@ -21,6 +35,12 @@ export class MasterPortfoliosController {
     ) {}
 
     @Post(':projectId/questions')
+    @ApiOperation({
+        summary: '마스터 포트폴리오 질문 AI 생성 API',
+        description: '프로젝트의 마스터 포트폴리오 질문을 AI로 생성합니다.',
+    })
+    @ApiParam({ name: 'projectId', type: Number, description: '프로젝트 ID' })
+    @ApiCommonResponseArray(QuestionResponseDto)
     async createQuestions(
         @Param('projectId', ParseIntPipe) projectId: number,
         @User('id') userId: number
@@ -28,15 +48,13 @@ export class MasterPortfoliosController {
         return this.masterPortfoliosService.createQuestions(userId, projectId);
     }
 
-    @Post(':projectId/')
-    async createMasterPortfolio(
-        @Param('projectId', ParseIntPipe) projectId: number,
-        @User('id') userId: number
-    ) {
-        return this.masterPortfoliosService.createMasterPortfolio(userId, projectId);
-    }
-
     @Post(':projectId/generate')
+    @ApiOperation({
+        summary: '마스터 포트폴리오 AI 생성 API',
+        description: '프로젝트의 마스터 포트폴리오를 AI로 생성합니다.',
+    })
+    @ApiParam({ name: 'projectId', type: Number, description: '프로젝트 ID' })
+    @ApiCommonResponse(MasterPortfolioResponseDto)
     async generateMasterPortfolio(
         @Param('projectId', ParseIntPipe) projectId: number,
         @User('id') userId: number
@@ -45,6 +63,17 @@ export class MasterPortfoliosController {
     }
 
     @Get(':projectId')
+    @ApiOperation({
+        summary: '마스터 포트폴리오 조회 API',
+        description: '프로젝트의 마스터 포트폴리오를 조회합니다.',
+    })
+    @ApiParam({ name: 'projectId', type: Number, description: '프로젝트 ID' })
+    @ApiCommonResponse(MasterPortfolioResponseDto)
+    @ApiCommonErrorResponse(
+        'MASTER_PORTFOLIO_NOT_FOUND',
+        '마스터 포트폴리오를 찾을 수 없습니다.',
+        404
+    )
     async getMasterPortfolio(
         @Param('projectId', ParseIntPipe) projectId: number,
         @User('id') userId: number
@@ -53,6 +82,18 @@ export class MasterPortfoliosController {
     }
 
     @Patch(':projectId')
+    @ApiOperation({
+        summary: '마스터 포트폴리오 업데이트 API',
+        description: '프로젝트의 마스터 포트폴리오를 업데이트합니다.',
+    })
+    @ApiParam({ name: 'projectId', type: Number, description: '프로젝트 ID' })
+    @ApiBody({ type: MasterPortfolioRequestDto })
+    @ApiCommonResponse(MasterPortfolioResponseDto)
+    @ApiCommonErrorResponse(
+        'MASTER_PORTFOLIO_NOT_FOUND',
+        '마스터 포트폴리오를 찾을 수 없습니다.',
+        404
+    )
     async updateMasterPortfolio(
         @Param('projectId', ParseIntPipe) projectId: number,
         @User('id') userId: number,

--- a/src/modules/master-portfolios/master-portfolios.service.ts
+++ b/src/modules/master-portfolios/master-portfolios.service.ts
@@ -28,6 +28,7 @@ export class MasterPortfoliosService {
         private readonly llmService: LLMService
     ) {}
 
+    // 마스터 포트폴리오 질문 생성
     async createQuestions(userId: number, projectId: number) {
         // 프로젝트 ID로 마스터 포트폴리오를 찾습니다.
         const masterPortfolio = await this.masterPortfolioRepository.findOne({
@@ -68,6 +69,7 @@ export class MasterPortfoliosService {
         return questionEntities;
     }
 
+    // 마스터 포트폴리오 AI 생성
     async generateMasterPortfolio(userId: number, projectId: number) {
         // 임시로 더미 데이터 사용
         let projectData: any;
@@ -102,6 +104,7 @@ export class MasterPortfoliosService {
         return MasterPortfolioResponseDto.from(generatedPortfolioResponse);
     }
 
+    // 프로젝트 종료 쪽으로 이동 후, 삭제 예정
     async createMasterPortfolio(userId: number, projectId: number) {
         const existingPortfolio = await this.masterPortfolioRepository.findOne({
             where: { user: { id: userId }, project: { id: projectId } },
@@ -118,6 +121,7 @@ export class MasterPortfoliosService {
         return MasterPortfolioResponseDto.from(masterPortfolio);
     }
 
+    // 마스터 포트폴리오 조회
     async getMasterPortfolio(userId: number, projectId: number) {
         const masterPortfolio = await this.masterPortfolioRepository.findOne({
             where: { user: { id: userId }, project: { id: projectId } },
@@ -128,6 +132,7 @@ export class MasterPortfoliosService {
         return MasterPortfolioResponseDto.from(masterPortfolio);
     }
 
+    // 마스터 포트폴리오 업데이트
     async updateMasterPortfolio(
         userId: number,
         projectId: number,


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #98 

## ✅ 작업 내용

- MasterPortfolio API 엔드포인트에 Swagger 명세 추가
- request와 response DTO에 @ApiProperty 추가
- 컨트롤러에서 createMasterPortfolio 삭제

## 📸 스크린샷

<img width="548" height="884" alt="image" src="https://github.com/user-attachments/assets/155b000e-9dc4-49d9-83dc-1e15c74b0a99" />
<img width="593" height="905" alt="image" src="https://github.com/user-attachments/assets/f9c93f65-9560-4988-b816-2c9281c475a7" />
<img width="505" height="908" alt="image" src="https://github.com/user-attachments/assets/d1e29ba3-4fc5-43a9-aa8b-04ddc8889a72" />
<img width="572" height="908" alt="image" src="https://github.com/user-attachments/assets/c0e75db8-12a9-4202-a8c9-b70dd3c7cdb7" />

## 📎 기타 참고사항
