### PR TITLE
[Chore] docker-compose.yml에 prompts 폴더 바인딩 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - REDIS_MAXMEMORY_POLICY=allkeys-lru
     volumes:
       - redis-data:/data
+      - /home/ubuntu/prompts:/app/src/common/prompts
     restart: unless-stopped
     mem_limit: 256m
     cpus: 0.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
     mem_limit: 512m
     cpus: 0.6
     memswap_limit: 1g
+    volumes:
+      - /home/ubuntu/prompts:/app/src/common/prompts
   redis_container:
     image: redis:latest
     container_name: teamie-redis
@@ -21,7 +23,6 @@ services:
       - REDIS_MAXMEMORY_POLICY=allkeys-lru
     volumes:
       - redis-data:/data
-      - /home/ubuntu/prompts:/app/src/common/prompts
     restart: unless-stopped
     mem_limit: 256m
     cpus: 0.3

--- a/src/modules/mappings/task-files/dtos/create-task-files.dto.ts
+++ b/src/modules/mappings/task-files/dtos/create-task-files.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { TaskFile } from  '../task-files.entity';
+import { TaskFile } from '../task-files.entity';
 export class TaskFileResponseDto {
     @ApiProperty({
         example: 'https://s3.amazonaws.com/bucket/file.jpg',

--- a/src/modules/tasks/dtos/update-task.dto.ts
+++ b/src/modules/tasks/dtos/update-task.dto.ts
@@ -100,10 +100,7 @@ export class UpdateTaskResponseDto {
     })
     stepId: number;
 
-    static from(
-        task: Task,
-        managers: Manager[]
-    ): UpdateTaskResponseDto {
+    static from(task: Task, managers: Manager[]): UpdateTaskResponseDto {
         const dto = new UpdateTaskResponseDto();
         dto.name = task.name;
         dto.deadline = task.deadline;


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #109 

## ✅ 작업 내용

- docker-compose.yml에 prompts 폴더 바인딩 추가
- 서버에 프롬프트 파일과 임시로 사용 중인 dummy-input.json 파일 추가

## 📸 스크린샷

<img width="449" height="72" alt="image" src="https://github.com/user-attachments/assets/feec24a5-664b-432d-a604-79d8a097f457" />

## 📎 기타 참고사항
