### PR TITLE
[Feat] Transaction Interceptor 구현 및 커스텀 데코레이터 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -57,7 +57,7 @@ import { TransactionInterceptor } from './common/interceptors/transaction.interc
         {
             provide: APP_GUARD,
             useClass: JwtAuthGuard,
-        }
+        },
     ],
 })
 export class AppModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,7 +11,7 @@ import type { RedisClientOptions } from 'redis';
 import { PersonalRecallsModule } from './modules/personal-recalls/personal-recalls.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { UsersModule } from './modules/users/users.module';
-import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
+import { APP_GUARD } from '@nestjs/core';
 import { JwtAuthGuard } from './modules/auth/guards/jwt-auth.gaurd';
 import { S3TestController } from './infra/upload/upload.controller';
 import { StepsModule } from './modules/steps/steps.module';
@@ -57,11 +57,7 @@ import { TransactionInterceptor } from './common/interceptors/transaction.interc
         {
             provide: APP_GUARD,
             useClass: JwtAuthGuard,
-        },
-        {
-            provide: APP_INTERCEPTOR,
-            useClass: TransactionInterceptor,
-        },
+        }
     ],
 })
 export class AppModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,7 +11,7 @@ import type { RedisClientOptions } from 'redis';
 import { PersonalRecallsModule } from './modules/personal-recalls/personal-recalls.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { UsersModule } from './modules/users/users.module';
-import { APP_GUARD } from '@nestjs/core';
+import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { JwtAuthGuard } from './modules/auth/guards/jwt-auth.gaurd';
 import { S3TestController } from './infra/upload/upload.controller';
 import { StepsModule } from './modules/steps/steps.module';
@@ -19,6 +19,7 @@ import { MasterPortfoliosModule } from './modules/master-portfolios/master-portf
 import { TaskFilesModule } from './modules/mappings/task-files/task-files.module';
 import { PlansModule } from './modules/plans/plans.module';
 import { CommentsModule } from './modules/comments/comments.module';
+import { TransactionInterceptor } from './common/interceptors/transaction.interceptor';
 @Module({
     imports: [
         ConfigModule.forRoot({
@@ -56,6 +57,10 @@ import { CommentsModule } from './modules/comments/comments.module';
         {
             provide: APP_GUARD,
             useClass: JwtAuthGuard,
+        },
+        {
+            provide: APP_INTERCEPTOR,
+            useClass: TransactionInterceptor,
         },
     ],
 })

--- a/src/common/decorators/transaction.decorator.ts
+++ b/src/common/decorators/transaction.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const TRANSACTIONAL_KEY = 'transactional';
+
+export const Transactional = () => SetMetadata(TRANSACTIONAL_KEY, true);

--- a/src/common/decorators/transaction.decorator.ts
+++ b/src/common/decorators/transaction.decorator.ts
@@ -1,5 +1,11 @@
-import { SetMetadata } from '@nestjs/common';
+import { applyDecorators, UseInterceptors } from '@nestjs/common';
+import { TransactionInterceptor } from '../interceptors/transaction.interceptor';
+import { Request } from 'express';
 
-export const TRANSACTIONAL_KEY = 'transactional';
+export function Transactional() {
+    return applyDecorators(UseInterceptors(TransactionInterceptor));
+}
 
-export const Transactional = () => SetMetadata(TRANSACTIONAL_KEY, true);
+export interface TransactionalRequest extends Request {
+    queryRunner: import('typeorm').QueryRunner;
+}

--- a/src/common/interceptors/transaction.interceptor.ts
+++ b/src/common/interceptors/transaction.interceptor.ts
@@ -2,7 +2,6 @@ import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nes
 import { Reflector } from '@nestjs/core';
 import { catchError, finalize, Observable, tap } from 'rxjs';
 import { DataSource, QueryRunner } from 'typeorm';
-import { TRANSACTIONAL_KEY } from '../decorators/transaction.decorator';
 
 @Injectable()
 export class TransactionInterceptor implements NestInterceptor {
@@ -11,14 +10,6 @@ export class TransactionInterceptor implements NestInterceptor {
         private readonly reflector: Reflector
     ) {}
     async intercept(context: ExecutionContext, next: CallHandler<any>): Promise<Observable<any>> {
-        const isTransactional = this.reflector.get<boolean>(
-            TRANSACTIONAL_KEY,
-            context.getHandler()
-        );
-        if (!isTransactional) {
-            return next.handle(); // 트랜잭션이 필요 없는 경우 그냥 다음 핸들러로 넘긴다.
-        }
-
         // 현재 실행 컨텍스트에 따라 request 또는 client 객체를 가져온다.
         let contextObject: any;
         const contextType = context.getType();
@@ -32,22 +23,24 @@ export class TransactionInterceptor implements NestInterceptor {
         }
 
         const qr: QueryRunner = this.dataSource.createQueryRunner();
+
         await qr.connect();
         await qr.startTransaction();
 
+        // contextObject에 queryRunner를 추가하여 서비스에서 사용할 수 있도록 한다.
         contextObject.queryRunner = qr;
 
         return next.handle().pipe(
-            catchError(async (error) => {
-                await qr.rollbackTransaction();
-                throw error;
-            }),
             tap(async () => {
+                // 성공적으로 처리된 경우 트랜잭션을 커밋한다.
                 await qr.commitTransaction();
-            }),
-            finalize(async () => {
                 await qr.release();
-                delete contextObject.queryRunner;
+            }),
+            catchError(async (error) => {
+                // 에러가 발생한 경우 트랜잭션을 롤백한다.
+                await qr.rollbackTransaction();
+                await qr.release();
+                throw error;
             })
         );
     }

--- a/src/common/interceptors/transaction.interceptor.ts
+++ b/src/common/interceptors/transaction.interceptor.ts
@@ -1,0 +1,54 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { catchError, finalize, Observable, tap } from 'rxjs';
+import { DataSource, QueryRunner } from 'typeorm';
+import { TRANSACTIONAL_KEY } from '../decorators/transaction.decorator';
+
+@Injectable()
+export class TransactionInterceptor implements NestInterceptor {
+    constructor(
+        private readonly dataSource: DataSource,
+        private readonly reflector: Reflector
+    ) {}
+    async intercept(context: ExecutionContext, next: CallHandler<any>): Promise<Observable<any>> {
+        const isTransactional = this.reflector.get<boolean>(
+            TRANSACTIONAL_KEY,
+            context.getHandler()
+        );
+        if (!isTransactional) {
+            return next.handle(); // 트랜잭션이 필요 없는 경우 그냥 다음 핸들러로 넘긴다.
+        }
+
+        // 현재 실행 컨텍스트에 따라 request 또는 client 객체를 가져온다.
+        let contextObject: any;
+        const contextType = context.getType();
+
+        if (contextType === 'http') {
+            contextObject = context.switchToHttp().getRequest();
+        } else if (contextType === 'ws') {
+            contextObject = context.switchToWs().getClient();
+        } else {
+            return next.handle(); // 지원하지 않는 컨텍스트 타입은 그냥 다음 핸들러로 넘긴다.
+        }
+
+        const qr: QueryRunner = this.dataSource.createQueryRunner();
+        await qr.connect();
+        await qr.startTransaction();
+
+        contextObject.queryRunner = qr;
+
+        return next.handle().pipe(
+            catchError(async (error) => {
+                await qr.rollbackTransaction();
+                throw error;
+            }),
+            tap(async () => {
+                await qr.commitTransaction();
+            }),
+            finalize(async () => {
+                await qr.release();
+                delete contextObject.queryRunner;
+            })
+        );
+    }
+}

--- a/src/modules/master-portfolios/master-portfolios.controller.ts
+++ b/src/modules/master-portfolios/master-portfolios.controller.ts
@@ -1,4 +1,14 @@
-import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Query, Req } from '@nestjs/common';
+import {
+    Body,
+    Controller,
+    Get,
+    Param,
+    ParseIntPipe,
+    Patch,
+    Post,
+    Query,
+    Req,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 import { PaginatedResponseDto } from 'src/common/response/paginated-response.dto';
@@ -70,7 +80,11 @@ export class MasterPortfoliosController {
         @Param('projectId', ParseIntPipe) projectId: number,
         @User('id') userId: number
     ) {
-        return this.masterPortfoliosService.generateMasterPortfolio(req.queryRunner, userId, projectId);
+        return this.masterPortfoliosService.generateMasterPortfolio(
+            req.queryRunner,
+            userId,
+            projectId
+        );
     }
 
     @Get(':projectId/generation-result')
@@ -124,12 +138,19 @@ export class MasterPortfoliosController {
         '마스터 포트폴리오를 찾을 수 없습니다.',
         404
     )
+    @Transactional()
     async updateMasterPortfolio(
+        @Req() req: TransactionalRequest,
         @Param('projectId', ParseIntPipe) projectId: number,
         @User('id') userId: number,
         @Body() updateDataDto: MasterPortfolioRequestDto
     ) {
-        return this.masterPortfoliosService.updateMasterPortfolio(userId, projectId, updateDataDto);
+        return this.masterPortfoliosService.updateMasterPortfolio(
+            req.queryRunner,
+            userId,
+            projectId,
+            updateDataDto
+        );
     }
 
     @Get('/me')

--- a/src/modules/master-portfolios/master-portfolios.controller.ts
+++ b/src/modules/master-portfolios/master-portfolios.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Query } from '@nestjs/common';
+import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Query, Req } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 import { PaginatedResponseDto } from 'src/common/response/paginated-response.dto';
@@ -18,6 +18,9 @@ import {
 import { QuestionResponseDto } from './dtos/question-response.dto';
 import { MasterPortfolioResponseDto } from './dtos/master-portfolio-response.dto';
 import { MasterPortfolioAIResponseDto } from './dtos/master-portfolio-ai-response.dto';
+import { Request } from 'express';
+import { QueryRunner } from 'typeorm';
+import { Transactional, TransactionalRequest } from 'src/common/decorators/transaction.decorator';
 
 @ApiTags('MasterPortfolios')
 @ApiBearerAuth('access-token')
@@ -40,11 +43,13 @@ export class MasterPortfoliosController {
         '마스터 포트폴리오를 찾을 수 없습니다.',
         404
     )
+    @Transactional()
     async createQuestions(
+        @Req() req: TransactionalRequest,
         @Param('projectId', ParseIntPipe) projectId: number,
         @User('id') userId: number
     ) {
-        return this.masterPortfoliosService.createQuestions(userId, projectId);
+        return this.masterPortfoliosService.createQuestions(req.queryRunner, userId, projectId);
     }
 
     @Post(':projectId/generate')
@@ -59,11 +64,13 @@ export class MasterPortfoliosController {
         '마스터 포트폴리오를 찾을 수 없습니다.',
         404
     )
+    @Transactional()
     async generateMasterPortfolio(
+        @Req() req: TransactionalRequest,
         @Param('projectId', ParseIntPipe) projectId: number,
         @User('id') userId: number
     ) {
-        return this.masterPortfoliosService.generateMasterPortfolio(userId, projectId);
+        return this.masterPortfoliosService.generateMasterPortfolio(req.queryRunner, userId, projectId);
     }
 
     @Get(':projectId/generation-result')

--- a/src/modules/master-portfolios/master-portfolios.service.ts
+++ b/src/modules/master-portfolios/master-portfolios.service.ts
@@ -165,18 +165,21 @@ export class MasterPortfoliosService {
 
     // 마스터 포트폴리오 업데이트
     async updateMasterPortfolio(
+        qr: QueryRunner,
         userId: number,
         projectId: number,
         updateDataDto: MasterPortfolioRequestDto
     ) {
-        await this.masterPortfolioRepository.update(
+        await qr.manager.update(
+            MasterPortfolio,
             {
                 user: { id: userId },
                 project: { id: projectId },
             },
             updateDataDto
         );
-        const masterPortfolio = await this.masterPortfolioRepository.findOne({
+
+        const masterPortfolio = await qr.manager.findOne(MasterPortfolio, {
             where: { user: { id: userId }, project: { id: projectId } },
         });
         if (!masterPortfolio) {

--- a/src/modules/master-portfolios/master-portfolios.service.ts
+++ b/src/modules/master-portfolios/master-portfolios.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Questions } from './entities/questions.entity';
-import { Repository } from 'typeorm';
+import { QueryRunner, Repository } from 'typeorm';
 import { MasterPortfolio } from './entities/master-portfolios.entity';
 import { LLMService } from 'src/infra/llm/llm.service';
 import { Question } from 'src/common/types/question.type';
@@ -19,7 +19,6 @@ import { UserMasterPortfoliosResponseDto } from './dtos/user-master-portfolios-r
 import { PaginatedResponseDto } from 'src/common/response/paginated-response.dto';
 import { MasterPortfolioAI } from './entities/master-portfolio-ai.entity';
 import { MasterPortfolioAIResponseDto } from './dtos/master-portfolio-ai-response.dto';
-import { Transactional } from 'src/common/decorators/transaction.decorator';
 
 @Injectable()
 export class MasterPortfoliosService {
@@ -34,10 +33,9 @@ export class MasterPortfoliosService {
     ) {}
 
     // 마스터 포트폴리오 질문 생성
-    @Transactional()
-    async createQuestions(userId: number, projectId: number) {
+    async createQuestions(qr: QueryRunner, userId: number, projectId: number) {
         // 프로젝트 ID로 마스터 포트폴리오를 찾습니다.
-        const masterPortfolio = await this.masterPortfolioRepository.findOne({
+        const masterPortfolio = await qr.manager.findOne(MasterPortfolio, {
             where: { project: { id: projectId }, user: { id: userId } },
         });
         if (!masterPortfolio) {
@@ -62,13 +60,13 @@ export class MasterPortfoliosService {
                     throw new Error(`Invalid question type: ${q.questionType}`);
                 }
 
-                const questionEntity = this.questionsRepository.create({
+                const questionEntity = qr.manager.create(Questions, {
                     questionId: q.id,
                     questionType: q.questionType as QuestionType,
                     question: q.question,
                     masterPortfolio: { id: masterPortfolioId },
                 });
-                const savedQuestion = await this.questionsRepository.save(questionEntity);
+                const savedQuestion = await qr.manager.save(Questions, questionEntity);
                 questionEntities.push(QuestionResponseDto.from(savedQuestion));
             } catch (e) {
                 console.error(`질문 생성 중 오류 발생: ${e.message}`);
@@ -80,9 +78,9 @@ export class MasterPortfoliosService {
     }
 
     // 마스터 포트폴리오 AI 생성
-    async generateMasterPortfolio(userId: number, projectId: number) {
+    async generateMasterPortfolio(qr: QueryRunner, userId: number, projectId: number) {
         // 프로젝트 ID로 마스터 포트폴리오를 찾습니다.
-        const masterPortfolio = await this.masterPortfolioRepository.findOne({
+        const masterPortfolio = await qr.manager.findOne(MasterPortfolio, {
             where: { project: { id: projectId }, user: { id: userId } },
         });
         if (!masterPortfolio) {
@@ -98,7 +96,7 @@ export class MasterPortfoliosService {
         }
 
         // 생성된 마스터 포트폴리오를 데이터베이스에 저장합니다.
-        const createdPortfolio = this.masterPortfolioAIRepository.create({
+        const createdPortfolio = qr.manager.create(MasterPortfolioAI, {
             user: { id: userId },
             project: { id: projectId },
             detailInfo: generatedPortfolio.detailInfo,
@@ -106,8 +104,9 @@ export class MasterPortfoliosService {
             keyAchievement: generatedPortfolio.keyAchievement,
             insight: generatedPortfolio.insight,
         });
+
         try {
-            await this.masterPortfolioAIRepository.save(createdPortfolio);
+            await qr.manager.save(MasterPortfolioAI, createdPortfolio);
         } catch (e) {
             console.error(`마스터 포트폴리오 AI 생성 중 오류 발생: ${e.message}`);
             throw new InternalServerErrorException(
@@ -116,7 +115,7 @@ export class MasterPortfoliosService {
         }
 
         // 생성된 마스터 포트폴리오 AI 결과를 반환합니다.
-        const generatedPortfolioResponse = await this.masterPortfolioAIRepository.findOne({
+        const generatedPortfolioResponse = await qr.manager.findOne(MasterPortfolioAI, {
             where: { user: { id: userId }, project: { id: projectId } },
         });
         if (!generatedPortfolioResponse) {

--- a/src/modules/master-portfolios/master-portfolios.service.ts
+++ b/src/modules/master-portfolios/master-portfolios.service.ts
@@ -19,6 +19,7 @@ import { UserMasterPortfoliosResponseDto } from './dtos/user-master-portfolios-r
 import { PaginatedResponseDto } from 'src/common/response/paginated-response.dto';
 import { MasterPortfolioAI } from './entities/master-portfolio-ai.entity';
 import { MasterPortfolioAIResponseDto } from './dtos/master-portfolio-ai-response.dto';
+import { Transactional } from 'src/common/decorators/transaction.decorator';
 
 @Injectable()
 export class MasterPortfoliosService {
@@ -33,6 +34,7 @@ export class MasterPortfoliosService {
     ) {}
 
     // 마스터 포트폴리오 질문 생성
+    @Transactional()
     async createQuestions(userId: number, projectId: number) {
         // 프로젝트 ID로 마스터 포트폴리오를 찾습니다.
         const masterPortfolio = await this.masterPortfolioRepository.findOne({
@@ -44,7 +46,11 @@ export class MasterPortfoliosService {
         const masterPortfolioId = masterPortfolio.id;
 
         // LLM을 호출하여 질문을 생성합니다.
-        const questions: Array<Question> = await this.llmService.generateQuestions();
+        // const questions: Array<Question> = await this.llmService.generateQuestions();
+        const questions: Array<Question> = [
+            { id: 1, questionType: QuestionType.TEXT, question: '테스트 질문 1' },
+            { id: 1, questionType: QuestionType.TEXT, question: '테스트 질문 2' },
+        ];
 
         // 생성된 질문들을 데이터베이스에 저장합니다.
         const questionEntities: QuestionResponseDto[] = [];
@@ -130,7 +136,7 @@ export class MasterPortfoliosService {
         return MasterPortfolioAIResponseDto.from(masterPortfolioAI);
     }
 
-    // 프로젝트 종료 쪽으로 이동 후, 삭제 예정
+    // 마스터 포트폴리오 생성 (project 종료할 때 사용)
     async createMasterPortfolio(userId: number, projectId: number) {
         const existingPortfolio = await this.masterPortfolioRepository.findOne({
             where: { user: { id: userId }, project: { id: projectId } },


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #96 

## ✅ 작업 내용

- Transaction Interceptor 추가
- @Transactional() 데코레이터 추가
- AI 질문 생성, AI 포트폴리오 생성, 포트폴리오 수정 메서드에 데코레이터 추가

## 📸 스크린샷

- 적용하기 전
  <img width="557" height="44" alt="image" src="https://github.com/user-attachments/assets/e0f9dbf9-ed77-48bf-8829-4a0d76a3330a" />
- 적용한 후
  <img width="398" height="242" alt="image" src="https://github.com/user-attachments/assets/339d8f4b-a0c3-47e5-ab89-16fb6afa82c6" />
  <img width="547" height="52" alt="image" src="https://github.com/user-attachments/assets/36c551ba-45af-4826-be25-e466ab2d3e79" />


## 📎 기타 참고사항

- 전역 등록 방식보다 @Transactional() 커스텀 데코레이터를 사용해서 적용하는 방식이 더 적합한 것 같아서 그렇게 구현했습니다.
- 전역 등록 방식은 [ 요청 -> 전역 인터셉터 실행 -> Reflector로 메타데이터 체크 -> 조건부 트랜잭션 로직 → 컨트롤러 실행 ] 이런 흐름으로 실행된다고 합니다.
- `transaction.interceptor.ts`에서 finalize() 사용하는 부분에 대해 고민 중
