### PR TITLE
[Refactor] 업무 대시보드 페이징 처리

### DIFF
--- a/src/modules/tasks/dtos/task-dashboard-status-view-dto.ts
+++ b/src/modules/tasks/dtos/task-dashboard-status-view-dto.ts
@@ -81,4 +81,10 @@ export class TaskDashboardStatusViewDto {
         description: '진행 상황별로 묶인 업무 정보',
     })
     statusGroups: StatusGroupDto[];
+
+    @ApiProperty({
+        example: 62,
+        description: '해당 프로젝트의 전체 업무 개수',
+    })
+    totalCount: number;
 }

--- a/src/modules/tasks/dtos/task-dashboard-step-view-dto.ts
+++ b/src/modules/tasks/dtos/task-dashboard-step-view-dto.ts
@@ -38,6 +38,7 @@ export class TaskInStepDto {
             userId: m.user.id,
             userName: m.user.name,
         }));
+
         return dto;
     }
 }
@@ -80,4 +81,10 @@ export class TaskDashboardStepViewDto {
         description: '단계별로 묶인 업무 정보',
     })
     steps: StepGroupDto[];
+
+    @ApiProperty({
+        example: 62,
+        description: '해당 프로젝트의 전체 업무 개수',
+    })
+    totalCount: number;
 }

--- a/src/modules/tasks/tasks.controller.ts
+++ b/src/modules/tasks/tasks.controller.ts
@@ -3,7 +3,6 @@ import {
     Controller,
     Post,
     Param,
-    Req,
     Get,
     Patch,
     Delete,
@@ -34,6 +33,7 @@ import {
     CreateCommentResponseDto,
     CreateCommentRequestDto,
 } from '../comments/dto/create-comment.dto';
+import { Status } from '../../common/enums/status.enum';
 import { CreateTaskFileResponseDto } from '../mappings/task-files/dtos/create-task-files.dto';
 @ApiTags('Tasks')
 @ApiBearerAuth('access-token')
@@ -42,7 +42,7 @@ export class TasksController {
     constructor(private readonly tasksService: TasksService) {}
 
     @ApiOperation({
-        summary: '업수 생성',
+        summary: '업무 생성',
         description: '새로운 업무를 생성합니다.',
     })
     @Post()
@@ -140,5 +140,34 @@ export class TasksController {
         @User('id') userId: number
     ): Promise<CreateTaskFileResponseDto> {
         return await this.tasksService.createTaskFile(userId, taskId, file);
+    }
+
+    @Get('/:projectId/dashboard/step/:stepId/more')
+    @ApiOperation({
+        summary: 'step별 업무 더보기',
+        description: 'step별로 더보기 버튼을 누르면 5개씩 추가로 보여줍니다.',
+    })
+    @ApiCommonResponse(GetTaskResponseDto)
+    async getStepMore(
+        @Param('projectId') projectId: number,
+        @Param('stepId') stepId: number,
+        @Query('offset') offset: number,
+        @Query('limit') limit = 5
+    ) {
+        return this.tasksService.getMoreTasksByStep(projectId, stepId, offset, limit);
+    }
+
+    @Get('/:projectId/dashboard/status/:status/more')
+    @ApiOperation({
+        summary: '진행상황별 업무 더보기',
+        description: '진행상황별로 더보기 버튼을 누르면 5개씩 추가로 보여줍니다.',
+    })
+    async getStatusMore(
+        @Param('projectId') projectId: number,
+        @Param('status') status: Status,
+        @Query('offset') offset: number,
+        @Query('limit') limit = 5
+    ) {
+        return this.tasksService.getMoreTasksByStatus(projectId, status, offset, limit);
     }
 }

--- a/src/modules/tasks/tasks.service.ts
+++ b/src/modules/tasks/tasks.service.ts
@@ -258,7 +258,17 @@ export class TasksService {
             .leftJoin('manager.user', 'user')
             .addSelect(['user.id', 'user.name'])
             .where('step.projectId = :projectId', { projectId })
+            .orderBy('task.deadline', 'ASC')
+            .addOrderBy('task.createdAt', 'ASC')
+            .limit(40)
             .getMany();
+
+        // 전체 업무 수 (더보기 버튼 표시 여부 판단)
+        const totalCount = await this.taskRepository
+            .createQueryBuilder('task')
+            .leftJoin('task.step', 'step')
+            .where('step.projectId = :projectId', { projectId })
+            .getCount();
 
         // 3. view 값에 따라 응답 구조 조립
         if (view === 'status') {
@@ -267,6 +277,7 @@ export class TasksService {
                 projectId: project.id,
                 projectName: project.name,
                 statusGroups,
+                totalCount,
             };
         } else {
             const stepGroups = this.groupByStep(tasks);
@@ -274,6 +285,7 @@ export class TasksService {
                 projectId: project.id,
                 projectName: project.name,
                 steps: stepGroups,
+                totalCount,
             };
         }
     }
@@ -387,5 +399,84 @@ export class TasksService {
 
         const saved = await this.taskFileRepository.save(taskFile);
         return CreateTaskFileResponseDto.fromEntity(saved);
+    }
+
+    // STEP별 더보기 API 
+    async getMoreTasksByStep(
+        projectId: number,
+        stepId: number,
+        offset: number,
+        limit: number = 5
+    ): Promise<{ tasks: TaskInStepDto[]; totalCount: number }> {
+        const step = await this.stepRepository.findOne({
+            where: { id: stepId, project: { id: projectId } },
+        });
+        if (!step) throw new StepNotFoundException('존재하지 않는 Step입니다.');
+
+        if (offset < 0) throw new BadRequestException('offset은 0 이상이어야 합니다.');
+        if (limit < 1 || limit > 50) throw new BadRequestException('limit은 1~50 사이여야 합니다.');
+
+        const tasks = await this.taskRepository
+            .createQueryBuilder('task')
+            .leftJoinAndSelect('task.step', 'step')
+            .leftJoin('task.managers', 'manager')
+            .leftJoin('manager.user', 'user')
+            .addSelect(['user.id', 'user.name'])
+            .where('step.projectId = :projectId', { projectId })
+            .andWhere('step.id = :stepId', { stepId })
+            .orderBy('task.deadline', 'ASC')
+            .addOrderBy('task.createdAt', 'ASC')
+            .skip(offset) // 이전까지 불러온 개수
+            .take(limit) // 새로 불러올 개수
+            .getMany();
+
+        const totalCount = await this.taskRepository
+            .createQueryBuilder('task')
+            .leftJoin('task.step', 'step')
+            .where('step.projectId = :projectId', { projectId })
+            .andWhere('step.id = :stepId', { stepId })
+            .getCount();
+
+        return { tasks: tasks.map((t) => TaskInStepDto.from(t)), totalCount };
+    }
+
+    // STATUS별 더보기 API 
+    async getMoreTasksByStatus(
+        projectId: number,
+        status: Status,
+        offset: number,
+        limit: number = 5
+    ): Promise<{ tasks: TaskInStatusDto[]; totalCount: number }> {
+        if (!Object.values(Status).includes(status)) {
+            throw new BadRequestException(
+                `status는 ${Object.values(Status).join(', ')} 중 하나여야 합니다.`
+            );
+        }
+
+        if (offset < 0) throw new BadRequestException('offset은 0 이상이어야 합니다.');
+        if (limit < 1 || limit > 50) throw new BadRequestException('limit은 1~50 사이여야 합니다.');
+
+        const tasks = await this.taskRepository
+            .createQueryBuilder('task')
+            .leftJoinAndSelect('task.step', 'step')
+            .leftJoin('task.managers', 'manager')
+            .leftJoin('manager.user', 'user')
+            .addSelect(['user.id', 'user.name'])
+            .where('step.projectId = :projectId', { projectId })
+            .andWhere('task.status = :status', { status })
+            .orderBy('task.deadline', 'ASC')
+            .addOrderBy('task.createdAt', 'ASC')
+            .skip(offset)
+            .take(limit)
+            .getMany();
+
+        const totalCount = await this.taskRepository
+            .createQueryBuilder('task')
+            .leftJoin('task.step', 'step')
+            .where('step.projectId = :projectId', { projectId })
+            .andWhere('task.status = :status', { status })
+            .getCount();
+
+        return { tasks: tasks.map((t) => TaskInStatusDto.from(t)), totalCount };
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #121

## ✅ 작업 내용

- 업무 대시보드 페이징 처리 기능 추가

    - 대시보드 API(GET /tasks/:projectId/dashboard)에서 초기 40개 업무만 조회하도록 수정
    - Step별/Status별로 5개씩 추가 로딩할 수 있는 더보기 API 구현

        - GET /tasks/:projectId/dashboard/step/:stepId/more

        - GET /tasks/:projectId/dashboard/status/:status/more

    - 마감일(deadline) → 생성일(createdAt) 순으로 정렬되도록 로직 개선



## 📸 스크린샷
- 성공 step
<img width="817" height="922" alt="step별성공" src="https://github.com/user-attachments/assets/03630bb4-3ff3-4e7b-a6fc-6e933eacd467" />
- 실패 step (존재하지 않는 step)
<img width="807" height="572" alt="step별존재하지않는step" src="https://github.com/user-attachments/assets/49e2fc92-4d0a-4fea-930b-c95521b37a4f" />
3-4f40-a1fd-3c01ebc844d4" />

- 성공 status
<img width="769" height="921" alt="status별성공" src="https://github.com/user-attachments/assets/cb94577c-e787-49c2-8b6f-555760d973db" />
- 실패 status(존재하지 않는 status)
<img width="768" height="477" alt="status별잘못된status" src="https://github.com/user-attachments/assets/96ee5dfd-e026-452c-ba2a-ec9b9d073d0d" />

- 공통 실패  (잘못된 offset)
<img width="692" height="556" alt="step별잘못된offset" src="https://github.com/user-attachments/assets/5fc43566-4122-442d-ae35-ce9a8b81e90e" />

## 📎 기타 참고사항

- 오타로 브랜치 fext로 만들어졌습니다
- 모든 API 응답에 totalCount 필드를 추가했습니다.

- 대시보드 API

    - totalCount: 프로젝트 전체 업무 개수 (초기 로딩 후 남은 데이터 여부 판단에 사용)

- Step별 더보기 API

    - totalCount: 해당 Step에 속한 전체 업무 개수

- Status별 더보기 API

    - totalCount: 해당 Status에 속한 전체 업무 개수    

- 프론트엔드 활용 방식

    - 프론트는 현재 로드된 tasks.length와 totalCount를 비교해 더보기 버튼 표시 여부를 제어
```ts
if (currentTasks.length >= totalCount) {
  // 모든 데이터를 다 불러온 상태 → 더보기 버튼 숨김
} else {
  // 아직 남은 데이터 있음 → 더보기 버튼 표시
}
