### PR TITLE
[Feat] 댓글 삭제 구현

### DIFF
--- a/src/common/exceptions/custom.errors.ts
+++ b/src/common/exceptions/custom.errors.ts
@@ -59,6 +59,17 @@ export class CommentUpdateForbiddenException extends CustomHttpException {
     }
 }
 
+export class CommentDeleteForbiddenException extends CustomHttpException {
+    constructor(data?: any) {
+        super(
+            ErrorCode.FORBIDDEN_COMMENT_FOR_UPDATE,
+            '본인이 작성한 댓글만 삭제할 수 있습니다.',
+            HttpStatus.FORBIDDEN,
+            data
+        );
+    }
+}
+
 export class AlreadyProjectCompletedException extends CustomHttpException {
     constructor(data?: any) {
         super(

--- a/src/modules/comments/comments.controller.ts
+++ b/src/modules/comments/comments.controller.ts
@@ -4,6 +4,9 @@ import { User } from 'src/common/decorators/user.decorator';
 import { CommentsService } from './comments.service';
 import { ApiCommonResponse } from 'src/common/response/swagger-response.helper';
 import { UpdateCommentResponseDto, UpdateCommentRequestDto } from './dto/update-comment.dto';
+import { Transactional } from 'src/common/decorators/transaction.decorator';
+import { CommonResponse } from 'src/common/response/common-response.dto';
+
 @ApiTags('Comments')
 @ApiBearerAuth('access-token')
 @Controller('/comments')
@@ -23,5 +26,19 @@ export class CommentsController {
         @User('id') userId: number
     ) {
         return await this.commentsService.updateComment(userId, commentId, dto);
+    }
+
+    @Delete('/:commentId')
+    @Transactional()
+    @ApiOperation({
+        summary: '댓글 삭제',
+        description: '댓글을 삭제합니다.',
+    })
+    @ApiOkResponse({ type: String, description: '댓글 삭제 성공' })
+    async deleteTask(
+        @Param('commentId') commentId: number,
+        @User('id') userId: number
+    ): Promise<CommonResponse> {
+        return this.commentsService.deleteComment(userId, commentId);
     }
 }

--- a/src/modules/comments/comments.controller.ts
+++ b/src/modules/comments/comments.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Param, Delete, Patch, Body } from '@nestjs/common';
+import { Controller, Param, Delete, Patch, Body, Req } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags, ApiOkResponse, ApiOperation, ApiBody } from '@nestjs/swagger';
 import { User } from 'src/common/decorators/user.decorator';
 import { CommentsService } from './comments.service';
@@ -6,6 +6,7 @@ import { ApiCommonResponse } from 'src/common/response/swagger-response.helper';
 import { UpdateCommentResponseDto, UpdateCommentRequestDto } from './dto/update-comment.dto';
 import { Transactional } from 'src/common/decorators/transaction.decorator';
 import { CommonResponse } from 'src/common/response/common-response.dto';
+import { TransactionalRequest } from 'src/common/decorators/transaction.decorator';
 
 @ApiTags('Comments')
 @ApiBearerAuth('access-token')
@@ -28,8 +29,8 @@ export class CommentsController {
         return await this.commentsService.updateComment(userId, commentId, dto);
     }
 
-    @Delete('/:commentId')
     @Transactional()
+    @Delete('/:commentId')
     @ApiOperation({
         summary: '댓글 삭제',
         description: '댓글을 삭제합니다.',
@@ -37,8 +38,9 @@ export class CommentsController {
     @ApiOkResponse({ type: String, description: '댓글 삭제 성공' })
     async deleteTask(
         @Param('commentId') commentId: number,
-        @User('id') userId: number
+        @User('id') userId: number,
+        @Req() req: TransactionalRequest, 
     ): Promise<CommonResponse> {
-        return this.commentsService.deleteComment(userId, commentId);
+        return this.commentsService.deleteComment(userId, commentId, req.queryRunner);
     }
 }

--- a/src/modules/comments/comments.service.ts
+++ b/src/modules/comments/comments.service.ts
@@ -9,6 +9,7 @@ import {
     CommentDeleteForbiddenException,
 } from 'src/common/exceptions/custom.errors';
 import { CommonResponse } from 'src/common/response/common-response.dto';
+import { QueryRunner } from 'typeorm';
 
 @Injectable()
 export class CommentsService {
@@ -39,10 +40,14 @@ export class CommentsService {
         return UpdateCommentResponseDto.from(updatedComment);
     }
 
-    async deleteComment(userId: number, commentId: number): Promise<CommonResponse> {
+    async deleteComment(
+        userId: number,
+        commentId: number,
+        queryRunner: QueryRunner
+    ): Promise<CommonResponse> {
         // 댓글 존재 여부 확인
-        const comment = await this.commentRepository
-            .createQueryBuilder('comment')
+        const comment = await queryRunner.manager
+            .createQueryBuilder(Comment, 'comment')
             .leftJoinAndSelect('comment.user', 'user')
             .where('comment.id = :commentId', { commentId })
             .getOne();

--- a/src/modules/comments/comments.service.ts
+++ b/src/modules/comments/comments.service.ts
@@ -6,7 +6,9 @@ import { UpdateCommentResponseDto, UpdateCommentRequestDto } from './dto/update-
 import {
     CommentUpdateForbiddenException,
     CommentNotFoundException,
+    CommentDeleteForbiddenException,
 } from 'src/common/exceptions/custom.errors';
+import { CommonResponse } from 'src/common/response/common-response.dto';
 
 @Injectable()
 export class CommentsService {
@@ -35,5 +37,28 @@ export class CommentsService {
 
         const updatedComment = await this.commentRepository.save(comment);
         return UpdateCommentResponseDto.from(updatedComment);
+    }
+
+    async deleteComment(userId: number, commentId: number): Promise<CommonResponse> {
+        // 댓글 존재 여부 확인
+        const comment = await this.commentRepository
+            .createQueryBuilder('comment')
+            .leftJoinAndSelect('comment.user', 'user')
+            .where('comment.id = :commentId', { commentId })
+            .getOne();
+
+        if (!comment) {
+            throw new CommentNotFoundException();
+        }
+
+        // 댓글 작성자와 로그인한 유저가 같은지 확인
+        if (comment.user.id !== userId) {
+            throw new CommentDeleteForbiddenException();
+        }
+
+        // 댓글 삭제
+        await this.commentRepository.delete({ id: commentId });
+
+        return CommonResponse.success({ message: `댓글 ID ${commentId} 삭제 완료` });
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #132

## ✅ 작업 내용

- 댓글 삭제 구현

## 📸 스크린샷
- 성공
<img width="549" height="726" alt="댓글삭제성공" src="https://github.com/user-attachments/assets/89d326ba-7799-4c10-8665-c1301bc6c4be" />

- 실패 - 존재하지 않는 댓글
<img width="548" height="697" alt="댓글삭제실패존재하지않는" src="https://github.com/user-attachments/assets/e93ce555-4cf4-45c2-a69d-5042918ea24e" />

- 실패 - 작성자가 아닐 경우
<img width="618" height="700" alt="댓글삭제실패본인댓글만" src="https://github.com/user-attachments/assets/03ae2e9f-7d82-4b70-b273-602b9eef478e" />


## 📎 기타 참고사항

- 
