### PR TITLE
[Feat]: 대댓글 생성 구현

### DIFF
--- a/src/modules/comments/cocomments/cocomments.entity.ts
+++ b/src/modules/comments/cocomments/cocomments.entity.ts
@@ -1,6 +1,7 @@
 import { BaseEntity } from 'src/common/entities/base.entity';
 import { Column, Entity, ManyToOne } from 'typeorm';
 import { Comment } from '../comments.entity';
+import { User } from '../../users/entities/users.entity';
 
 @Entity()
 export class Cocomment extends BaseEntity {
@@ -11,4 +12,7 @@ export class Cocomment extends BaseEntity {
         onDelete: 'CASCADE',
     })
     comment: Comment;
+
+    @ManyToOne(() => User, (user) => user.cocomments, { onDelete: 'CASCADE' })
+    user: User;
 }

--- a/src/modules/comments/cocomments/dto/create-cocomment.dto.ts
+++ b/src/modules/comments/cocomments/dto/create-cocomment.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty } from 'class-validator';
+import { Comment } from '../../comments.entity';
+import { Cocomment } from '../cocomments.entity';
+
+export class CreateCocommentRequestDto {
+    @ApiProperty({
+        example: 1,
+        description: '대댓글 작성할 댓글 Id',
+    })
+    @IsNotEmpty()
+    commentId: number;
+
+    @ApiProperty({
+        example: '업무 기한 다음주로 바꿔야할 것 같아요',
+        description: '댓글 내용',
+    })
+    @IsNotEmpty()
+    content: string;
+}
+
+export class CreateCocommentResponseDto {
+    @ApiProperty({
+        example: 1,
+        description: '대댓글 ID',
+    })
+    cocommentId: number;
+
+    @ApiProperty({
+        example: '업무 기한 다음주로 바꿔야할 것 같아요',
+        description: '댓글 내용',
+    })
+    @IsNotEmpty()
+    content: string;
+
+    static from(cocomment: Cocomment): CreateCocommentResponseDto {
+        const dto = new CreateCocommentResponseDto();
+        dto.cocommentId = cocomment.id;
+        dto.content = cocomment.content;
+        return dto;
+    }
+}

--- a/src/modules/comments/cocomments/dto/create-cocomment.dto.ts
+++ b/src/modules/comments/cocomments/dto/create-cocomment.dto.ts
@@ -5,13 +5,6 @@ import { Cocomment } from '../cocomments.entity';
 
 export class CreateCocommentRequestDto {
     @ApiProperty({
-        example: 1,
-        description: '대댓글 작성할 댓글 Id',
-    })
-    @IsNotEmpty()
-    commentId: number;
-
-    @ApiProperty({
         example: '업무 기한 다음주로 바꿔야할 것 같아요',
         description: '댓글 내용',
     })

--- a/src/modules/comments/comments.controller.ts
+++ b/src/modules/comments/comments.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Param, Delete, Patch, Body, Req } from '@nestjs/common';
+import { Controller, Param, Delete, Patch, Body, Req, Post } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags, ApiOkResponse, ApiOperation, ApiBody } from '@nestjs/swagger';
 import { User } from 'src/common/decorators/user.decorator';
 import { CommentsService } from './comments.service';
@@ -7,6 +7,10 @@ import { UpdateCommentResponseDto, UpdateCommentRequestDto } from './dto/update-
 import { Transactional } from 'src/common/decorators/transaction.decorator';
 import { CommonResponse } from 'src/common/response/common-response.dto';
 import { TransactionalRequest } from 'src/common/decorators/transaction.decorator';
+import {
+    CreateCocommentResponseDto,
+    CreateCocommentRequestDto,
+} from './cocomments/dto/create-cocomment.dto';
 
 @ApiTags('Comments')
 @ApiBearerAuth('access-token')
@@ -36,11 +40,27 @@ export class CommentsController {
         description: '댓글을 삭제합니다.',
     })
     @ApiOkResponse({ type: String, description: '댓글 삭제 성공' })
-    async deleteTask(
+    async deleteComment(
         @Param('commentId') commentId: number,
         @User('id') userId: number,
-        @Req() req: TransactionalRequest, 
+        @Req() req: TransactionalRequest
     ): Promise<CommonResponse> {
         return this.commentsService.deleteComment(userId, commentId, req.queryRunner);
+    }
+
+    @Transactional()
+    @Post('/:commentId')
+    @ApiOperation({
+        summary: '대댓글 생성',
+        description: '대댓글을 생성합니다.',
+    })
+    @ApiCommonResponse(CreateCocommentResponseDto)
+    async createCocoment(
+        @Param('commentId') commentId: number,
+        @User('id') userId: number,
+        @Req() req: TransactionalRequest,
+        @Body() dto: CreateCocommentRequestDto
+    ): Promise<CreateCocommentResponseDto> {
+        return this.commentsService.createCocomment(userId, commentId, dto, req.queryRunner);
     }
 }

--- a/src/modules/comments/comments.controller.ts
+++ b/src/modules/comments/comments.controller.ts
@@ -48,12 +48,12 @@ export class CommentsController {
         return this.commentsService.deleteComment(userId, commentId, req.queryRunner);
     }
 
-    @Transactional()
-    @Post('/:commentId')
     @ApiOperation({
         summary: '대댓글 생성',
         description: '대댓글을 생성합니다.',
     })
+    @Transactional()
+    @Post('/:commentId/cocomments')
     @ApiCommonResponse(CreateCocommentResponseDto)
     async createCocoment(
         @Param('commentId') commentId: number,

--- a/src/modules/comments/comments.module.ts
+++ b/src/modules/comments/comments.module.ts
@@ -4,8 +4,10 @@ import { ConfigModule } from '@nestjs/config';
 import { Comment } from './comments.entity';
 import { CommentsController } from './comments.controller';
 import { CommentsService } from './comments.service';
+import { Cocomment } from './cocomments/cocomments.entity';
+
 @Module({
-    imports: [TypeOrmModule.forFeature([Comment]), ConfigModule],
+    imports: [TypeOrmModule.forFeature([Comment, Cocomment]), ConfigModule],
     controllers: [CommentsController],
     providers: [CommentsService],
 })

--- a/src/modules/comments/comments.service.ts
+++ b/src/modules/comments/comments.service.ts
@@ -10,12 +10,20 @@ import {
 } from 'src/common/exceptions/custom.errors';
 import { CommonResponse } from 'src/common/response/common-response.dto';
 import { QueryRunner } from 'typeorm';
+import { Cocomment } from './cocomments/cocomments.entity';
+import {
+    CreateCocommentRequestDto,
+    CreateCocommentResponseDto,
+} from './cocomments/dto/create-cocomment.dto';
 
 @Injectable()
 export class CommentsService {
     constructor(
         @InjectRepository(Comment)
-        private readonly commentRepository: Repository<Comment>
+        private readonly commentRepository: Repository<Comment>,
+
+        @InjectRepository(Cocomment)
+        private readonly cocommentRepository: Repository<Cocomment>
     ) {}
 
     async updateComment(userId: number, commentId: number, dto: UpdateCommentRequestDto) {
@@ -65,5 +73,31 @@ export class CommentsService {
         await this.commentRepository.delete({ id: commentId });
 
         return CommonResponse.success({ message: `댓글 ID ${commentId} 삭제 완료` });
+    }
+
+    async createCocomment(
+        userId: number,
+        commentId: number,
+        dto: CreateCocommentRequestDto,
+        queryRunner: QueryRunner
+    ): Promise<CreateCocommentResponseDto> {
+        // 1. 대댓글 작성할 댓글 있는지
+        const comment = await queryRunner.manager
+            .createQueryBuilder(Comment, 'comment')
+            .where('comment.id = :commentId', { commentId })
+            .getOne();
+
+        if (!comment) throw new CommentNotFoundException();
+
+        // 2. 댓글 생성 및 저장
+        const cocomment = queryRunner.manager.create(Cocomment, {
+            user: { id: userId },
+            comment: { id: commentId },
+            content: dto.content,
+        });
+        const saved = await queryRunner.manager.save(Cocomment, cocomment);
+
+        // 3. 응답 반환
+        return CreateCocommentResponseDto.from(saved);
     }
 }

--- a/src/modules/users/entities/users.entity.ts
+++ b/src/modules/users/entities/users.entity.ts
@@ -10,6 +10,7 @@ import { Writer } from '../../mappings/writers/writers.entity';
 import { Attendee } from '../../mappings/attendees/attendees.entity';
 import { MasterPortfolio } from '../../master-portfolios/entities/master-portfolios.entity';
 import { FinalPortfolio } from '../../final-portfolios/final-portfolios.entity';
+import { Cocomment } from '../../comments/cocomments/cocomments.entity';
 
 @Entity()
 export class User extends BaseEntity {
@@ -58,6 +59,9 @@ export class User extends BaseEntity {
 
     @OneToMany(() => Comment, (comment) => comment.user)
     comments: Comment[];
+
+    @OneToMany(() => Cocomment, (cocomment) => cocomment.user)
+    cocomments: Cocomment[];
 
     @OneToMany(() => PersonalRecall, (personalRecall) => personalRecall.user)
     personalRecalls: PersonalRecall[];


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #137 

## ✅ 작업 내용

- 대댓글 생성 구현
- user와 cocomment사이의 관계가 정의되어있지 않아서
    - User 엔티티에 cocomments 필드(@OneToMany) 추가
    - Cocomment 엔티티에 users 필드(@ManyToOne) 추가

## 📸 스크린샷

- 성공
<img width="871" height="664" alt="대댓글생성성공" src="https://github.com/user-attachments/assets/7d41f65c-97be-43eb-a630-96d46179a41f" />

- 실패
<img width="867" height="679" alt="대댓글생성실패" src="https://github.com/user-attachments/assets/6736c5dd-ceec-42f1-9f42-917eeeaa5d07" />

## 📎 기타 참고사항

-
