### PR TITLE
[Feat]: 대댓글 삭제 구현

### DIFF
--- a/src/modules/comments/cocomments/cocomments.controller.ts
+++ b/src/modules/comments/cocomments/cocomments.controller.ts
@@ -32,5 +32,20 @@ export class CocommentsController {
     }
 
 
+    @ApiOperation({
+        summary: '대댓글 삭제',
+        description: '대댓글을 삭제합니다.',
+    })
+    @ApiOkResponse({type: String, description: '대댓글 삭제 성공'})
+    @Transactional()
+    @Delete('/:cocommentId')
+    async deleteCocomment(
+        @Param('cocommentId') cocommentId: number,
+        @User('id') userId: number,
+        @Req() req: TransactionalRequest
+    ): Promise<CommonResponse> {
+        return this.cocommentsService.deleteCocomment(userId, cocommentId, req.queryRunner);
+    }
+
     
 }

--- a/src/modules/comments/cocomments/cocomments.service.ts
+++ b/src/modules/comments/cocomments/cocomments.service.ts
@@ -47,4 +47,31 @@ export class CocommentsService {
 
         return UpdateCocommentResponseDto.from(updatedComment);
     }
+
+    async deleteCocomment(
+            userId: number,
+            cocommentId: number,
+            queryRunner: QueryRunner
+        ): Promise<CommonResponse> {
+            // 대댓글 존재 여부 확인
+            const cocomment = await queryRunner.manager
+                .createQueryBuilder(Cocomment, 'cocomment')
+                .leftJoinAndSelect('cocomment.user', 'user')
+                .where('cocomment.id = :cocommentId', { cocommentId })
+                .getOne();
+    
+            if (!cocomment) {
+                throw new CocommentNotFoundException();
+            }
+    
+            // 대댓글 작성자와 로그인한 유저가 같은지 확인
+            if (cocomment.user.id !== userId) {
+                throw new CocommentDeleteForbiddenException();
+            }
+    
+            // 대댓글 삭제
+            await queryRunner.manager.delete(Cocomment, { id: cocommentId });
+    
+            return CommonResponse.success({ message: `대댓글 ID ${cocommentId} 삭제 완료` });
+        }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #147 

## ✅ 작업 내용

- 대댓글 삭제 구현
- 본인이 작성한 댓글만 삭제할 수 있도록 에러처리

## 📸 스크린샷

- 성공
<img width="527" height="586" alt="대댓글삭제성공" src="https://github.com/user-attachments/assets/726589a7-61e7-490d-a149-89bbb768998d" />

- 실패 - 존재하지않는 댓글
<img width="482" height="578" alt="대댓글삭제실패존재하지않음" src="https://github.com/user-attachments/assets/fae17e4d-7fc8-448d-9d14-426d7d6a4fd2" />

- 실패 - 본인이 작성하지 않은 댓글
<img width="521" height="607" alt="대댓글삭제실패본인댓글만" src="https://github.com/user-attachments/assets/db4d780b-113d-4256-876c-3af01c342194" />

## 📎 기타 참고사항

- 
