### PR TITLE
[Feat] 댓글 조회 구현

### DIFF
--- a/src/modules/comments/dto/get-comment.dto.ts
+++ b/src/modules/comments/dto/get-comment.dto.ts
@@ -1,0 +1,154 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty } from 'class-validator';
+import { Comment } from '../comments.entity';
+import { User } from '../../users/entities/users.entity';
+import { Cocomment } from '../cocomments/cocomments.entity';
+
+
+export class UserInCommentDto {
+    @ApiProperty({
+        example: 'https://s3:example.com/profile/example.png',
+        description: '사용자 프로필 이미지 url',
+    })
+    imageUrl: string;
+
+    @ApiProperty({
+        example: '홍길동',
+        description: '나의 프로필-이름',
+    })
+    name: string;
+
+    static from(user: User): UserInCommentDto {
+        const dto = new UserInCommentDto();
+        dto.imageUrl = user.imageUrl;
+        dto.name = user.name;
+        return dto;
+    }
+}
+
+export class CocommentInCommentDto{
+    @ApiProperty({
+        example: 1,
+        description: '대댓글 ID',
+    })
+    cocommentId: number;
+
+    @ApiProperty({
+        example: '업무 기한 다음주로 바꿔야할 것 같아요',
+        description: '대댓글 내용',
+    })
+    @IsNotEmpty()
+    content: string;
+
+    @ApiProperty({
+        example: 1,
+        description: '대댓글 생성된 시간',
+    })
+    createdAt: Date;
+
+    @ApiProperty({
+        example: 1,
+        description: '대댓글 수정된 시간',
+    })
+    updatedAt: Date;
+
+    @ApiProperty({
+        type: UserInCommentDto,
+        description: '해당 대댓글을 작성한 유저 정보',
+    })
+    users: UserInCommentDto;
+
+    static from(cocomment: Cocomment): CocommentInCommentDto {
+        const dto = new CocommentInCommentDto();
+        dto.cocommentId = cocomment.id;
+        dto.content = cocomment.content;
+        dto.createdAt = cocomment.createdAt;
+        dto.updatedAt = cocomment.updatedAt;
+        dto.users = UserInCommentDto.from(cocomment.user);
+        return dto;
+    }
+
+}
+
+export class CommentGroupDto {
+    @ApiProperty({
+        example: 1,
+        description: '댓글 I',
+    })
+    @IsNotEmpty()
+    commentId: number;
+
+    @ApiProperty({
+        example: '업무 기한 다음주로 바꿔야할 것 같아요',
+        description: '댓글 내용',
+    })
+    @IsNotEmpty()
+    content: string;
+
+    @ApiProperty({
+        example: 1,
+        description: '댓글 생성된 시간',
+    })
+    createdAt: Date;
+
+    @ApiProperty({
+        example: 1,
+        description: '댓글 수정된 시간',
+    })
+    updatedAt: Date;
+
+    @ApiProperty({
+        type: UserInCommentDto,
+        description: '해당 댓글을 작성한 유저 정보',
+    })
+    users: UserInCommentDto;
+
+    @ApiProperty({
+        type: [CocommentInCommentDto],
+        description: '해당 댓글을 포함된 대댓글 목록',
+    })
+    cocomments: CocommentInCommentDto[];
+
+    static from(comment: Comment): CommentGroupDto {
+        const dto = new CommentGroupDto();
+        dto.commentId = comment.id;
+        dto.content = comment.content;
+        dto.createdAt = comment.createdAt;
+        dto.updatedAt = comment.updatedAt;
+        dto.users = UserInCommentDto.from(comment.user);
+        dto.cocomments = comment.cocomments?.map(c => CocommentInCommentDto.from(c)) || [];
+        return dto;
+    }
+}
+
+
+
+export class GetCommentResponseDto {
+    @ApiProperty({
+        example: 42,
+        description: '댓글 갯수',
+    })
+    @IsNotEmpty()
+    totalCount: number;
+
+    @ApiProperty({
+        example: true,
+        description: '가져올 댓글이 있는지 여부',
+    })
+    @IsNotEmpty()
+    hasMore: boolean;
+
+    @ApiProperty({
+        type: [CommentGroupDto],
+        description: '댓글목록',
+    })
+    comments: CommentGroupDto[];
+
+    static from(comments: Comment[], totalCount: number, offset: number, limit: number): GetCommentResponseDto {
+        const dto = new GetCommentResponseDto();
+        dto.totalCount = totalCount;
+        dto.hasMore = offset + limit < totalCount; 
+        dto.comments = comments.map(comment => CommentGroupDto.from(comment));
+        return dto;
+    }
+}

--- a/src/modules/tasks/tasks.controller.ts
+++ b/src/modules/tasks/tasks.controller.ts
@@ -170,4 +170,16 @@ export class TasksController {
     ) {
         return this.tasksService.getMoreTasksByStatus(projectId, status, offset, limit);
     }
+
+    @Get('/:taskId/comments')
+    @ApiOperation({
+        summary: '업무별 댓글 조회',
+        description: '업무별로 댓글과 대댓글을 조회합니다',
+    })
+    async getComment(
+        @Param('taskId') taskId: number,
+        @Query('offset') offset: number,
+    ) {
+        return this.tasksService.getComment(taskId, offset);
+    }
 }

--- a/src/modules/tasks/tasks.service.ts
+++ b/src/modules/tasks/tasks.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, DeepPartial } from 'typeorm';
+import { Repository } from 'typeorm';
 import { Task } from './tasks.entity';
 import { Step } from '../steps/entities/steps.entity';
 import { UserProject } from '../mappings/user-projects/userProjects.entity';
-import { CreateTaskRequestDto, CreateTaskResponseDto } from './dtos/create-task.dto';
+import { CreateTaskRequestDto} from './dtos/create-task.dto';
 import {
     CreateCommentResponseDto,
     CreateCommentRequestDto,
@@ -22,6 +22,7 @@ import { TaskDashboardStatusViewDto } from './dtos/task-dashboard-status-view-dt
 import { StepGroupDto, TaskInStepDto } from './dtos/task-dashboard-step-view-dto';
 import { StatusGroupDto, TaskInStatusDto } from './dtos/task-dashboard-status-view-dto';
 import { CreateTaskFileResponseDto } from '../mappings/task-files/dtos/create-task-files.dto';
+import { GetCommentResponseDto, UserInCommentDto, CocommentInCommentDto } from '../comments/dto/get-comment.dto';
 import { Status } from '../../common/enums/status.enum';
 import {
     ProjectForbiddenException,
@@ -478,5 +479,64 @@ export class TasksService {
             .getCount();
 
         return { tasks: tasks.map((t) => TaskInStatusDto.from(t)), totalCount };
+    }
+
+
+    //업무별 댓글 조회
+    async getComment(
+        taskId: number,
+        offset: number,
+    ): Promise<GetCommentResponseDto> {
+        const task = await this.taskRepository.findOne({
+            where: { id: taskId },
+        });
+
+        if (!task) {
+            throw new TaskNotFoundException();
+        }
+
+        if (offset < 0) {
+            throw new BadRequestException('offset은 0 이상이어야 합니다.');
+        }
+
+        const limit = 10; 
+
+        // 댓글 조회 (댓글 작성자 + 대댓글 + 대댓글 작성자까지 한번에 조인)
+        const comments = await this.commentRepository
+            .createQueryBuilder('comment')
+            .leftJoinAndSelect('comment.user', 'user')  // 댓글 작성자
+            .leftJoinAndSelect('comment.cocomments', 'cocomment') // 대댓글
+            .leftJoinAndSelect('cocomment.user', 'cocommentUser') // 대댓글 작성자
+            .where('comment.taskId = :taskId', { taskId })
+            .orderBy('comment.createdAt', 'DESC')
+            .addOrderBy('cocomment.createdAt', 'DESC')
+            .skip(offset)
+            .take(limit)
+            .select([
+                'comment.id',
+                'comment.content',
+                'comment.createdAt',
+                'comment.updatedAt',
+                'user.id',
+                'user.name',
+                'user.imageUrl',
+                'cocomment.id',
+                'cocomment.content',
+                'cocomment.createdAt',
+                'cocomment.updatedAt',
+                'cocommentUser.id',
+                'cocommentUser.name',
+                'cocommentUser.imageUrl',
+            ])
+            .getMany();
+
+
+        // 댓글 총 개수 (hasMore 계산용)
+        const totalCount = await this.commentRepository.count({
+            where: { task: { id: taskId } },
+        });
+
+        // DTO 변환 
+        return GetCommentResponseDto.from(comments, totalCount, offset, limit);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #150 

## ✅ 작업 내용

- 댓글 조회 구현
- 댓글 기준으로 10개씩 페이징 처리
- 사용자 이름, 프로필url, 대댓글 함께 조회

## 📸 스크린샷

- 성공
<img width="701" height="652" alt="댓글조회성공" src="https://github.com/user-attachments/assets/b976982f-de44-4685-bdab-b97c23d23572" />

- 실패 - 존재하지않는 업무
- 
<img width="1314" height="634" alt="스크린샷 2025-07-30 143807" src="https://github.com/user-attachments/assets/97377851-f165-4d3c-ba9c-4e1f458e8a71" />

## 📎 기타 참고사항

- 
