### PR TITLE
[Fix] 프로젝트 완료 시 참여코드도 만료, 트랜잭션 오류 해결

### DIFF
--- a/src/modules/master-portfolios/master-portfolios.service.ts
+++ b/src/modules/master-portfolios/master-portfolios.service.ts
@@ -20,6 +20,7 @@ import { UserMasterPortfoliosResponseDto } from './dtos/user-master-portfolios-r
 import { PaginatedResponseDto } from 'src/common/response/paginated-response.dto';
 import { MasterPortfolioAI } from './entities/master-portfolio-ai.entity';
 import { MasterPortfolioAIResponseDto } from './dtos/master-portfolio-ai-response.dto';
+import { EntityManager } from 'typeorm';
 
 @Injectable()
 export class MasterPortfoliosService {
@@ -137,7 +138,7 @@ export class MasterPortfoliosService {
     }
 
     // 마스터 포트폴리오 생성 (project 종료할 때 사용)
-    async createMasterPortfolio(userId: number, projectId: number) {
+    async createMasterPortfolio(manager: EntityManager, userId: number, projectId: number) {
         const existingPortfolio = await this.masterPortfolioRepository.findOne({
             where: { user: { id: userId }, project: { id: projectId } },
         });
@@ -149,7 +150,7 @@ export class MasterPortfoliosService {
             user: { id: userId },
             project: { id: projectId },
         });
-        await this.masterPortfolioRepository.save(masterPortfolio);
+        await manager.save(MasterPortfolio, masterPortfolio);
         return MasterPortfolioResponseDto.from(masterPortfolio);
     }
 

--- a/src/modules/projects/projects.service.ts
+++ b/src/modules/projects/projects.service.ts
@@ -125,7 +125,7 @@ export class ProjectsService {
         //meta 키 추가
         const now = new Date();
         const expiresAt = new Date(now.getTime() + this.POST_TTL_SECONDS * 1000).toISOString();
-        await this.redis.set(`invite:meta:${code}`, '', /* no EX */);
+        await this.redis.set(`invite:meta:${code}`, '' /* no EX */);
 
         // 프로젝트 별 코드 목록 Set
         await this.redis.sAdd(`project:${projectId}:invites`, code);
@@ -274,16 +274,16 @@ export class ProjectsService {
 
         // 5) 프로젝트 완료 시 Redis에 남아 있는 URL 캐시, 해시도 같이 삭제 삭제
         // 1) Set 에서 이 프로젝트의 모든 inviteCode 조회
-const setKey = `project:${projectId}:invites`;
-const codes = await this.redis.sMembers(setKey);
+        const setKey = `project:${projectId}:invites`;
+        const codes = await this.redis.sMembers(setKey);
 
-if (codes.length) {
-  // 2) 남은 invite:<code> 삭제(메타는 남겨둠)
-  const delKeys = codes.flatMap(c => [`invite:${c}`]);
-  await this.redis.del(delKeys);
-  // 3) Set 자체도 삭제
-  await this.redis.del(setKey);
-}
+        if (codes.length) {
+            // 2) 남은 invite:<code> 삭제(메타는 남겨둠)
+            const delKeys = codes.flatMap((c) => [`invite:${c}`]);
+            await this.redis.del(delKeys);
+            // 3) Set 자체도 삭제
+            await this.redis.del(setKey);
+        }
 
         // 6) 응답 반환
         return CompleteProjectResponseDto.fromEntity(project);
@@ -561,29 +561,28 @@ if (codes.length) {
 
     // 참여코드로 프로젝트 id 조회
     private async getProjectByInviteCode(inviteCode: string) {
-    const codeKey = `invite:${inviteCode}`;
-    const metaKey = `invite:meta:${inviteCode}`;
+        const codeKey = `invite:${inviteCode}`;
+        const metaKey = `invite:meta:${inviteCode}`;
 
-     // 1) 정상: invite:<code>가 살아 있으면
-  const projectIdStr = await this.redis.get(codeKey);
-  if (!projectIdStr) {
-    // 2) 완료(만료된 링크): meta 키만 남아 있으면
-     if (await this.redis.exists(metaKey)) {
-        const metaProjectIdStr = await this.redis.get(metaKey);
-        if (metaProjectIdStr) {
-          throw new AlreadyProjectCompletedException();
-        }else{
-            throw new ExpiredInvitecodeException();
+        // 1) 정상: invite:<code>가 살아 있으면
+        const projectIdStr = await this.redis.get(codeKey);
+        if (!projectIdStr) {
+            // 2) 완료(만료된 링크): meta 키만 남아 있으면
+            if (await this.redis.exists(metaKey)) {
+                const metaProjectIdStr = await this.redis.get(metaKey);
+                if (metaProjectIdStr) {
+                    throw new AlreadyProjectCompletedException();
+                } else {
+                    throw new ExpiredInvitecodeException();
+                }
+            } else {
+                throw new InvalidInvitecodeException();
+            }
         }
-  }
-  else{
-    throw new InvalidInvitecodeException();
-  }
-  }
 
-  const projectId = Number(projectIdStr);
-    return projectId;
-}
+        const projectId = Number(projectIdStr);
+        return projectId;
+    }
     // user와 project 매핑 존재 확인
     private async isUserInProject(userId: number, projectId: number): Promise<boolean> {
         return await this.userProjectRepository.exists({

--- a/src/modules/projects/projects.service.ts
+++ b/src/modules/projects/projects.service.ts
@@ -111,26 +111,27 @@ export class ProjectsService {
             // 여기서 예외 나면 트랜잭션 인터셉터가 롤백합니다
             throw new ProjectTransactionException();
         }
+
+        // invite:<code> -> projectId (문자열 키)
         const code = generateRandomCode();
         const key = `invite:${code}`;
         const ttlSeconds = 60 * 60 * 24 * 3; //3일
-        await this.redis.set(key, savedProject.id.toString());
+        const projectId = savedProject.id.toString();
+        await this.redis.set(key, projectId);
         await this.redis.expire(key, ttlSeconds);
 
         const inviteCode = `${code}`;
 
         const now = new Date();
         const expiresAt = new Date(now.getTime() + this.POST_TTL_SECONDS * 1000).toISOString();
-        await this.redis.hSet('invite:meta', code, expiresAt);
+        await this.redis.hSet(`invite:${projectId}`, code, expiresAt);
         return CreateProjectResponseDto.fromEntity(savedProject, inviteCode, expiresAt);
     }
 
     async joinValidate(userId: number, inviteCode: string): Promise<ValidateInviteResponseDto> {
         // 1) 초대 코드 유효성 검사 (Expired vs Invalid 예외 포함)
         const projectId = await this.getProjectByInviteCode(inviteCode);
-        if (projectId == null) {
-            throw new InvalidInvitecodeException();
-        }
+
         // 2) 이미 참여한 사용자라면 예외
         const alreadyJoined = await this.isUserInProject(userId, projectId);
         if (alreadyJoined) {
@@ -264,10 +265,25 @@ export class ProjectsService {
             throw new ProjectTransactionException();
         }
 
-        // 4) 트랜잭션 범위 밖에서 MasterPortfolio 생성
-        await this.masterPortfoliosService.createMasterPortfolio(userId, projectId);
+        // 4) 트랜잭션 넘겨서 MasterPortfolio 생성
+        await this.masterPortfoliosService.createMasterPortfolio(qr.manager, userId, projectId);
 
-        // 5) 응답 반환
+        // 5) 프로젝트 완료 시 Redis에 남아 있는 URL 캐시, 해시도 같이 삭제 삭제
+        const hashKey = `invite:${projectId}`;
+
+        // 해시에 남아 있는 모든 inviteCode 조회
+        const codes: string[] = await this.redis.hKeys(hashKey);
+
+        if (codes.length > 0) {
+            // 각 invite:<code> 문자열 키 삭제
+            const inviteKeys = codes.map((code) => `invite:${code}`);
+            await this.redis.del(inviteKeys);
+        }
+
+        // 프로젝트별 해시 자체 삭제
+        await this.redis.del(hashKey);
+
+        // 6) 응답 반환
         return CompleteProjectResponseDto.fromEntity(project);
     }
     async createStep(
@@ -545,14 +561,16 @@ export class ProjectsService {
     private async getProjectByInviteCode(inviteCode: string) {
         const key = `invite:${inviteCode}`;
         const projectIdStr = await this.redis.get(key);
-        if (projectIdStr == null) return null; //키가 없으면 null 리턴
-        // 숫자로 변환
-        const metaTs = await this.redis.hGet('invite:meta', inviteCode);
-        if (metaTs) {
-            // 메타만 남아 있으면 TTL 만료 → expired
-            throw new ExpiredInvitecodeException();
-        }
         const projectId = Number(projectIdStr);
+        if (projectIdStr == null) {
+            const metaTs = await this.redis.hGet(`invite:${projectId}`, inviteCode);
+            if (metaTs) {
+                // hset 남아 있으면 TTL 만료 → 만료된 링크 에러
+                throw new ExpiredInvitecodeException();
+            } else {
+                throw new InvalidInvitecodeException(); //키가 없으면 유효하지 않은 코드라고 에러 표시
+            }
+        }
         return projectId;
     }
 

--- a/src/modules/projects/projects.service.ts
+++ b/src/modules/projects/projects.service.ts
@@ -122,9 +122,13 @@ export class ProjectsService {
 
         const inviteCode = `${code}`;
 
+        //meta 키 추가
         const now = new Date();
         const expiresAt = new Date(now.getTime() + this.POST_TTL_SECONDS * 1000).toISOString();
-        await this.redis.hSet(`invite:${projectId}`, code, expiresAt);
+        await this.redis.set(`invite:meta:${code}`, '', /* no EX */);
+
+        // 프로젝트 별 코드 목록 Set
+        await this.redis.sAdd(`project:${projectId}:invites`, code);
         return CreateProjectResponseDto.fromEntity(savedProject, inviteCode, expiresAt);
     }
 
@@ -269,19 +273,17 @@ export class ProjectsService {
         await this.masterPortfoliosService.createMasterPortfolio(qr.manager, userId, projectId);
 
         // 5) 프로젝트 완료 시 Redis에 남아 있는 URL 캐시, 해시도 같이 삭제 삭제
-        const hashKey = `invite:${projectId}`;
+        // 1) Set 에서 이 프로젝트의 모든 inviteCode 조회
+const setKey = `project:${projectId}:invites`;
+const codes = await this.redis.sMembers(setKey);
 
-        // 해시에 남아 있는 모든 inviteCode 조회
-        const codes: string[] = await this.redis.hKeys(hashKey);
-
-        if (codes.length > 0) {
-            // 각 invite:<code> 문자열 키 삭제
-            const inviteKeys = codes.map((code) => `invite:${code}`);
-            await this.redis.del(inviteKeys);
-        }
-
-        // 프로젝트별 해시 자체 삭제
-        await this.redis.del(hashKey);
+if (codes.length) {
+  // 2) 남은 invite:<code> 삭제(메타는 남겨둠)
+  const delKeys = codes.flatMap(c => [`invite:${c}`]);
+  await this.redis.del(delKeys);
+  // 3) Set 자체도 삭제
+  await this.redis.del(setKey);
+}
 
         // 6) 응답 반환
         return CompleteProjectResponseDto.fromEntity(project);
@@ -559,21 +561,29 @@ export class ProjectsService {
 
     // 참여코드로 프로젝트 id 조회
     private async getProjectByInviteCode(inviteCode: string) {
-        const key = `invite:${inviteCode}`;
-        const projectIdStr = await this.redis.get(key);
-        const projectId = Number(projectIdStr);
-        if (projectIdStr == null) {
-            const metaTs = await this.redis.hGet(`invite:${projectId}`, inviteCode);
-            if (metaTs) {
-                // hset 남아 있으면 TTL 만료 → 만료된 링크 에러
-                throw new ExpiredInvitecodeException();
-            } else {
-                throw new InvalidInvitecodeException(); //키가 없으면 유효하지 않은 코드라고 에러 표시
-            }
-        }
-        return projectId;
-    }
+    const codeKey = `invite:${inviteCode}`;
+    const metaKey = `invite:meta:${inviteCode}`;
 
+     // 1) 정상: invite:<code>가 살아 있으면
+  const projectIdStr = await this.redis.get(codeKey);
+  if (!projectIdStr) {
+    // 2) 완료(만료된 링크): meta 키만 남아 있으면
+     if (await this.redis.exists(metaKey)) {
+        const metaProjectIdStr = await this.redis.get(metaKey);
+        if (metaProjectIdStr) {
+          throw new AlreadyProjectCompletedException();
+        }else{
+            throw new ExpiredInvitecodeException();
+        }
+  }
+  else{
+    throw new InvalidInvitecodeException();
+  }
+  }
+
+  const projectId = Number(projectIdStr);
+    return projectId;
+}
     // user와 project 매핑 존재 확인
     private async isUserInProject(userId: number, projectId: number): Promise<boolean> {
         return await this.userProjectRepository.exists({


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #48 

## ✅ 작업 내용

- 프로젝트 완료 시 redis에 연결된  poject:{projectId} 해시 키 삭제 (해당 프로젝트 참여코드와 만료 시기를 담은 해시)
- 해당 해시 키에 담긴 참여 코드를 바탕으로 invite:{inviteCode} 키들도 모두 삭제 -> 만료되어서 redis 삭제처리
- meta:{inviteCode}만 남겨서 유효기간이 지난건지 원래 없던건지 구분해서 검사
- 완료시 마스터 포트폴리오 생성할 때 생기는 트랜잭션 오류를 qr.manager를 메서드에 넘겨서 같은 트랜잭션 섹션 안에서 함께 생성하도록 버그 수정

## 📸 스크린샷

프로젝트 생성 후 참여 코드 유효성 검사

![스크린샷_1-8-2025_15155_localhost](https://github.com/user-attachments/assets/a437b931-b5fc-4367-8c8e-6320984397c2)
-> 이미 참여했다고 에러 뜸

프로젝트 완료 후 참여 코드 유효성 검사

<img width="2363" height="10862" alt="image" src="https://github.com/user-attachments/assets/b1018e32-dbba-4a4e-a9af-60c3595438e4" />

-> 원래는 완료되었다고 떠야하는데 계속 고치다가 이제 진짜 테스트 영상 찍어야해서 나중에 수정할게요..

redis에서 유효 코드만 삭제하고 테스트 (임의로 url 만료 처리)

![스크린샷_1-8-2025_154647_localhost](https://github.com/user-attachments/assets/296fd6bc-b12f-4068-92c0-6faf43850eb3)

## 📎 기타 참고사항

- 완료 에러 수정 필요
