### PR TITLE
[Feat] 선택 가능한 회의록 조회 api 구현

### DIFF
--- a/src/modules/master-portfolios/dtos/selectable-plan.dto.ts
+++ b/src/modules/master-portfolios/dtos/selectable-plan.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Plan } from 'src/modules/plans/entities/plan.entity';
+
+export class SelectablePlanResponseDto {
+    @ApiProperty({ description: '일정 ID', type: Number, example: 1 })
+    id: number;
+    @ApiProperty({ description: '일정 이름', type: String, example: '회의 이름1' })
+    name: string;
+    @ApiProperty({ description: '일정 날짜', type: Date, example: '2025-08-18T10:00:00.000Z' })
+    date: Date;
+    @ApiProperty({ description: '회의록', type: String, example: '회의록 내용' })
+    meetingRecords: string;
+
+    static fromEntity(entity: Plan): SelectablePlanResponseDto {
+        const dto = new SelectablePlanResponseDto();
+        dto.id = entity.id;
+        dto.name = entity.name;
+        dto.date = entity.date;
+        dto.meetingRecords = entity.meetingRecords;
+        return dto;
+    }
+}

--- a/src/modules/master-portfolios/master-portfolios.controller.ts
+++ b/src/modules/master-portfolios/master-portfolios.controller.ts
@@ -30,6 +30,7 @@ import { DateCursor } from 'src/common/dtos/date-cursor.dto';
 import { MasterPortfolioAIResponseDto } from './dtos/master-portfolio-ai-response.dto';
 import { Transactional, TransactionalRequest } from 'src/common/decorators/transaction.decorator';
 import { CreateQuestions } from './dtos/create-questions.dto';
+import { SelectablePlanResponseDto } from './dtos/selectable-plan.dto';
 
 @ApiTags('MasterPortfolios')
 @Controller('master-portfolios')
@@ -167,8 +168,8 @@ export class MasterPortfoliosController {
     @Transactional()
     async updateMasterPortfolio(
         @Req() req: TransactionalRequest,
-        @Param('portfolioId', ParseIntPipe) portfolioId: number,
         @User('id') userId: number,
+        @Param('portfolioId', ParseIntPipe) portfolioId: number,
         @Body() updateDataDto: MasterPortfolioRequestDto
     ) {
         return this.masterPortfoliosService.updateMasterPortfolio(
@@ -177,5 +178,20 @@ export class MasterPortfoliosController {
             portfolioId,
             updateDataDto
         );
+    }
+
+    // 선택 가능한 회의록 조회 API
+    @ApiOperation({
+        summary: '선택 가능한 회의록 조회 API',
+        description: '프로젝트의 일정 중에 사용자가 참여한 일정 목록을 조회합니다.',
+    })
+    @ApiParam({ name: 'portfolioId', type: Number, description: '포트폴리오 ID' })
+    @ApiCommonResponseArray(SelectablePlanResponseDto)
+    @Get(':portfolioId/records')
+    async getProjectRecords(
+        @User('id') userId: number,
+        @Param('portfolioId', ParseIntPipe) portfolioId: number
+    ) {
+        return this.masterPortfoliosService.getProjectRecords(userId, portfolioId);
     }
 }

--- a/src/modules/master-portfolios/master-portfolios.module.ts
+++ b/src/modules/master-portfolios/master-portfolios.module.ts
@@ -7,10 +7,11 @@ import { MasterPortfolio } from './entities/master-portfolios.entity';
 import { LLMModule } from 'src/infra/llm/llm.module';
 import { MasterPortfolioAI } from './entities/master-portfolio-ai.entity';
 import { Project } from '../projects/entities/projects.entity';
+import { Plan } from '../plans/entities/plan.entity';
 
 @Module({
     imports: [
-        TypeOrmModule.forFeature([Questions, MasterPortfolio, MasterPortfolioAI, Project]),
+        TypeOrmModule.forFeature([Questions, MasterPortfolio, MasterPortfolioAI, Project, Plan]),
         LLMModule,
     ],
     controllers: [MasterPortfoliosController],

--- a/src/modules/master-portfolios/master-portfolios.service.ts
+++ b/src/modules/master-portfolios/master-portfolios.service.ts
@@ -30,6 +30,7 @@ import { Project } from '../projects/entities/projects.entity';
 import { EntityManager } from 'typeorm';
 import { User } from '../users/entities/users.entity';
 import { UserProject } from '../mappings/user-projects/userProjects.entity';
+import { SelectablePlanResponseDto } from './dtos/selectable-plan.dto';
 
 function getPeriod(createdAt: Date, completedAt: Date): string {
     let years = completedAt.getFullYear() - createdAt.getFullYear();
@@ -67,6 +68,8 @@ export class MasterPortfoliosService {
         private readonly masterPortfolioAIRepository: Repository<MasterPortfolioAI>,
         @InjectRepository(Project)
         private readonly projectRepository: Repository<Project>,
+        @InjectRepository(Plan)
+        private readonly planRepository: Repository<Plan>,
         private readonly llmService: LLMService
     ) {}
 
@@ -97,6 +100,7 @@ export class MasterPortfoliosService {
             await qr.manager.update(Plan, { id: recordId }, { masterPortfolioId });
         }
 
+        // TODO: 가져오는 데이터가 많음, 정리할 것
         // 가져올 데이터
         // 1. 선택된 회의록 내용
         const records = await qr.manager.find(Plan, {
@@ -381,5 +385,28 @@ export class MasterPortfoliosService {
         }
         if (masterPortfolio.user.id !== userId) return false;
         return true;
+    }
+
+    // 선택 가능한 회의록 조회
+    async getProjectRecords(userId: number, portfolioId: number) {
+        const masterPortfolio = await this.masterPortfolioRepository.findOne({
+            where: { id: portfolioId, user: { id: userId } },
+            relations: ['project'],
+        });
+        if (!masterPortfolio) {
+            throw new MasterPortfolioNotFoundException();
+        }
+        const projectId = masterPortfolio.project?.id;
+
+        // projectId에 해당하는 프로젝트에서 해당 user가 참여한 일정만 가져오기 (참석자 기준)
+        const plans = await this.planRepository.find({
+            where: { project: { id: projectId }, attendees: { user: { id: userId } } },
+            select: ['id', 'name', 'date', 'meetingRecords'],
+            order: { date: 'ASC' }, // 날짜 빠른 순으로 정렬
+        });
+
+        // TODO: 글자 수 바탕으로 토큰 수 계산 -> 토큰 수 바탕으로 크레딧 계산 (BM 확정 필요)
+
+        return plans.map((plan) => SelectablePlanResponseDto.fromEntity(plan));
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #184 

## ✅ 작업 내용

- 선택 가능한 회의록 조회 api 구현
- SelectablePlanResponseDto 추가
- Swagger 작성

## 📸 스크린샷

- 가져올 회의록 있는 경우
  <img width="619" height="627" alt="image" src="https://github.com/user-attachments/assets/7804c11f-5ad0-4514-ba91-8683947a52b8" />

- 가져올 회의록 없는 경우
  <img width="625" height="514" alt="image" src="https://github.com/user-attachments/assets/a8c49eb1-c87e-4034-8330-49823e4d9501" />

## 📎 기타 참고사항

- (BM 확정 시에 추가적으로 구현 필요) 회의록의 글자 수를 바탕으로 토큰 수를 계산 -> 이를 바탕으로 크레딧 계산
