### PR TITLE
[Feat] CORS 다중 origin 지원 및 쿼리 파라미터 redirect_url에 대한 리다이렉트 지원

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
                 "class-transformer": "^0.5.1",
                 "class-validator": "^0.14.2",
                 "cookie-parser": "^1.4.7",
+                "express-session": "^1.18.2",
                 "multer": "^2.0.1",
                 "mysql2": "^3.14.1",
                 "passport": "^0.7.0",
@@ -8166,6 +8167,42 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/express-session": {
+            "version": "1.18.2",
+            "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
+            "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
+            "dependencies": {
+                "cookie": "0.7.2",
+                "cookie-signature": "1.0.7",
+                "debug": "2.6.9",
+                "depd": "~2.0.0",
+                "on-headers": "~1.1.0",
+                "parseurl": "~1.3.3",
+                "safe-buffer": "5.2.1",
+                "uid-safe": "~2.1.5"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/express-session/node_modules/cookie-signature": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+            "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="
+        },
+        "node_modules/express-session/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/express-session/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        },
         "node_modules/express/node_modules/content-disposition": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
@@ -10875,6 +10912,14 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/on-headers": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+            "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -11504,6 +11549,14 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/random-bytes": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+            "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/randombytes": {
@@ -13516,6 +13569,17 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/uid-safe": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+            "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+            "dependencies": {
+                "random-bytes": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/uid2": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "cookie-parser": "^1.4.7",
+        "express-session": "^1.18.2",
         "multer": "^2.0.1",
         "mysql2": "^3.14.1",
         "passport": "^0.7.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,16 +7,37 @@ import { defaultConfig } from './config/app.config';
 import { SwaggerModule } from '@nestjs/swagger';
 import { createSwaggerConfig, publicPaths } from './config/swagger.config';
 import * as cookieParser from 'cookie-parser';
+import * as session from 'express-session';
 
 async function bootstrap() {
     const app = await NestFactory.create(AppModule);
 
+    const rawOrigins = process.env.CORS_ORIGIN || 'http://localhost:3000';
+    const allowedOrigins = rawOrigins.split(',').map(origin => origin.trim());
     app.enableCors({
-        origin: process.env.CORS_ORIGIN || 'http://localhost:3000',
+        origin: (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) => {
+            if (!origin) return callback(null, true);
+            if (allowedOrigins.includes(origin)) {
+                return callback(null, true);
+            } else {
+                return callback(new Error(`CORS: ${origin} is not allowed`), false);
+            }
+        },
         methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
         credentials: true,
     });
     app.use(cookieParser());
+
+    app.use(
+        session({
+            secret: process.env.SESSION_SECRET,
+            resave: false,
+            saveUninitialized: false,
+            cookie: {
+                maxAge: 360000,
+            },
+        }),
+    );
 
     const configService = app.get(ConfigService);
     const config = defaultConfig(configService);

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,9 +13,12 @@ async function bootstrap() {
     const app = await NestFactory.create(AppModule);
 
     const rawOrigins = process.env.CORS_ORIGIN || 'http://localhost:3000';
-    const allowedOrigins = rawOrigins.split(',').map(origin => origin.trim());
+    const allowedOrigins = rawOrigins.split(',').map((origin) => origin.trim());
     app.enableCors({
-        origin: (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) => {
+        origin: (
+            origin: string | undefined,
+            callback: (err: Error | null, allow?: boolean) => void
+        ) => {
             if (!origin) return callback(null, true);
             if (allowedOrigins.includes(origin)) {
                 return callback(null, true);
@@ -36,7 +39,7 @@ async function bootstrap() {
             cookie: {
                 maxAge: 360000,
             },
-        }),
+        })
     );
 
     const configService = app.get(ConfigService);

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -24,7 +24,7 @@ export class AuthController {
     @ApiQuery({
         name: 'redirect_url',
         description: '리다이렉트 될 base_url을 쿼리 파라미터로 포함합니다.',
-        required: false
+        required: false,
     })
     @ApiResponse({
         status: 302,
@@ -33,7 +33,7 @@ export class AuthController {
     @Pulbic()
     @UseGuards(SetRedirectUrlGuard, AuthGuard('kakao'))
     @Get('/kakao')
-    async kakaoLogin(@Query('redirect_url') redirect_url?: string,) {}
+    async kakaoLogin(@Query('redirect_url') redirect_url?: string) {}
 
     @ApiOperation({
         summary: '카카오 로그인 콜백',
@@ -47,18 +47,25 @@ export class AuthController {
     @Pulbic()
     @UseGuards(AuthGuard('kakao'))
     @Get('/kakao/callback')
-    async kakaoCallback(@Req() req: any, @KakaoUser() user: KakaoUserAfterAuth, @Res() res: Response): Promise<void> {
+    async kakaoCallback(
+        @Req() req: any,
+        @KakaoUser() user: KakaoUserAfterAuth,
+        @Res() res: Response
+    ): Promise<void> {
         // 클라이언트 요청 host 파싱
-        const baseRedirect = req.session.redirectUrl || this.configService.get('CLIENT_REDIRECT_URI') || 'http://localhost:3000';
+        const baseRedirect =
+            req.session.redirectUrl ||
+            this.configService.get('CLIENT_REDIRECT_URI') ||
+            'http://localhost:3000';
         const safeOrigin = this.authService.validateRedirectOrigin(baseRedirect)
             ? baseRedirect
             : this.configService.get('CLIENT_REDIRECT_URI') || 'http://localhost:3000';
         const redirectPath = this.configService.get('CLIENT_REDIRECT_PATH') || '/docs';
         // 슬래시 중복 방지
-        const fullRedirect = safeOrigin.endsWith('/') 
+        const fullRedirect = safeOrigin.endsWith('/')
             ? safeOrigin.slice(0, -1) + redirectPath
             : safeOrigin + redirectPath;
-        
+
         // 사용자 인증 by JWT
         const kakaoUser = user;
         const accessToken = await this.authService.handleKakaoLogin(kakaoUser);

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,11 +1,13 @@
-import { Controller, Get, Res, UseGuards } from '@nestjs/common';
+import { Controller, Get, Query, Req, Res, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { AuthService } from './auth.service';
 import { ConfigService } from '@nestjs/config';
 import { KakaoUser, KakaoUserAfterAuth } from 'src/common/decorators/user.decorator';
 import { Response } from 'express';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Pulbic } from 'src/common/decorators/public.decorator';
+import { SetRedirectUrlGuard } from './guards/set-redirect-url.guard';
+import { InternalServerError } from 'src/common/exceptions/custom.errors';
 
 @ApiTags('Auth')
 @Controller('/auth')
@@ -19,14 +21,19 @@ export class AuthController {
         summary: '카카오 로그인 트리거',
         description: '카카오 인증페이지로 리다이렉트합니다. 스웨거에서 누르지 마세요.',
     })
+    @ApiQuery({
+        name: 'redirect_url',
+        description: '리다이렉트 될 base_url을 쿼리 파라미터로 포함합니다.',
+        required: false
+    })
     @ApiResponse({
         status: 302,
         description: '카카오 로그인 페이지로 리다이렉트됨.',
     })
     @Pulbic()
-    @UseGuards(AuthGuard('kakao'))
+    @UseGuards(SetRedirectUrlGuard, AuthGuard('kakao'))
     @Get('/kakao')
-    async kakaoLogin() {}
+    async kakaoLogin(@Query('redirect_url') redirect_url?: string,) {}
 
     @ApiOperation({
         summary: '카카오 로그인 콜백',
@@ -40,17 +47,39 @@ export class AuthController {
     @Pulbic()
     @UseGuards(AuthGuard('kakao'))
     @Get('/kakao/callback')
-    async kakaoCallback(@KakaoUser() req: KakaoUserAfterAuth, @Res() res: Response): Promise<void> {
-        const kakaoUser = req;
+    async kakaoCallback(@Req() req: any, @KakaoUser() user: KakaoUserAfterAuth, @Res() res: Response): Promise<void> {
+        // 클라이언트 요청 host 파싱
+        const baseRedirect = req.session.redirectUrl || this.configService.get('CLIENT_REDIRECT_URI') || 'http://localhost:3000';
+        const safeOrigin = this.authService.validateRedirectOrigin(baseRedirect)
+            ? baseRedirect
+            : this.configService.get('CLIENT_REDIRECT_URI') || 'http://localhost:3000';
+        const redirectPath = this.configService.get('CLIENT_REDIRECT_PATH') || '/docs';
+        // 슬래시 중복 방지
+        const fullRedirect = safeOrigin.endsWith('/') 
+            ? safeOrigin.slice(0, -1) + redirectPath
+            : safeOrigin + redirectPath;
+        
+        // 사용자 인증 by JWT
+        const kakaoUser = user;
         const accessToken = await this.authService.handleKakaoLogin(kakaoUser);
-        res.cookie('accessToken', accessToken, {
-            httpOnly: true,
-            secure: true,
-            sameSite: 'none',
-            maxAge: this.configService.get('JWT_EXPIRES_IN') || 1000 * 60 * 60, // 1시간
+        req.session.destroy((err: Error) => {
+            if (err) {
+                throw new InternalServerError('세션 파괴 중 에러 발생');
+            }
+            res.clearCookie('connect.sid', {
+                httpOnly: true,
+                secure: true,
+                sameSite: 'none',
+            });
+
+            res.cookie('accessToken', accessToken, {
+                httpOnly: true,
+                secure: true,
+                sameSite: 'none',
+                maxAge: this.configService.get('JWT_EXPIRES_IN') || 1000 * 60 * 60, // 1시간
+            });
+            //TODO: 추후 refreshToken 구현 필요
+            res.redirect(fullRedirect);
         });
-        //TODO: 추후 refreshToken 구현 필요
-        const url = this.configService.get('CLIENT_REDIRECT_URI') || 'http://localhost:3000/docs';
-        res.redirect(url);
     }
 }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -4,12 +4,14 @@ import { UsersService } from '../users/users.service';
 import { JwtService } from '@nestjs/jwt';
 import { UserInvariantViolationException } from 'src/common/exceptions/custom.errors';
 import { WsException } from '@nestjs/websockets';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class AuthService {
     constructor(
         private readonly userService: UsersService,
-        private readonly jwtService: JwtService
+        private readonly jwtService: JwtService,
+        private readonly configService: ConfigService
     ) {}
 
     async handleKakaoLogin(kakaoUser: KakaoUserAfterAuth): Promise<String> {
@@ -41,6 +43,17 @@ export class AuthService {
             return payload.userId;
         } catch (err) {
             throw new WsException('Invalid token');
+        }
+    }
+
+    validateRedirectOrigin(url: string): boolean {
+        try{
+            const parsed = new URL(url);
+            const rawOrigins: string = this.configService.get('CORS_ORIGIN')|| 'http://localhost:3000';
+            const allowedOrigins = rawOrigins.split(',').map(origin => origin.trim());
+            return allowedOrigins.includes(parsed.origin);
+        } catch {
+            return false;
         }
     }
 }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -47,10 +47,11 @@ export class AuthService {
     }
 
     validateRedirectOrigin(url: string): boolean {
-        try{
+        try {
             const parsed = new URL(url);
-            const rawOrigins: string = this.configService.get('CORS_ORIGIN')|| 'http://localhost:3000';
-            const allowedOrigins = rawOrigins.split(',').map(origin => origin.trim());
+            const rawOrigins: string =
+                this.configService.get('CORS_ORIGIN') || 'http://localhost:3000';
+            const allowedOrigins = rawOrigins.split(',').map((origin) => origin.trim());
             return allowedOrigins.includes(parsed.origin);
         } catch {
             return false;

--- a/src/modules/auth/guards/set-redirect-url.guard.ts
+++ b/src/modules/auth/guards/set-redirect-url.guard.ts
@@ -1,5 +1,5 @@
-import { CanActivate, ExecutionContext, Injectable } from "@nestjs/common";
-import { Observable } from "rxjs";
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Observable } from 'rxjs';
 
 @Injectable()
 export class SetRedirectUrlGuard implements CanActivate {
@@ -7,7 +7,7 @@ export class SetRedirectUrlGuard implements CanActivate {
         const request = context.switchToHttp().getRequest();
         const { redirect_url } = request.query;
 
-        if(redirect_url) {
+        if (redirect_url) {
             request.session.redirectUrl = redirect_url;
         }
 

--- a/src/modules/auth/guards/set-redirect-url.guard.ts
+++ b/src/modules/auth/guards/set-redirect-url.guard.ts
@@ -1,0 +1,16 @@
+import { CanActivate, ExecutionContext, Injectable } from "@nestjs/common";
+import { Observable } from "rxjs";
+
+@Injectable()
+export class SetRedirectUrlGuard implements CanActivate {
+    canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
+        const request = context.switchToHttp().getRequest();
+        const { redirect_url } = request.query;
+
+        if(redirect_url) {
+            request.session.redirectUrl = redirect_url;
+        }
+
+        return true;
+    }
+}

--- a/src/modules/auth/strategies/kakao.strategy.ts
+++ b/src/modules/auth/strategies/kakao.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { Profile, Strategy } from 'passport-kakao';
+import { InternalServerError } from 'src/common/exceptions/custom.errors';
 
 @Injectable()
 export class KakaoStrategy extends PassportStrategy(Strategy) {
@@ -18,7 +19,6 @@ export class KakaoStrategy extends PassportStrategy(Strategy) {
         accessToken: string,
         refreshToken: string,
         profile: Profile,
-        done: (error: any, user?: any, info?: any) => void
     ): Promise<any> {
         try {
             const { _json } = profile;
@@ -28,9 +28,9 @@ export class KakaoStrategy extends PassportStrategy(Strategy) {
                 email: _json.kakao_account?.email,
                 profileImage: _json.properties?.profile_image,
             };
-            done(null, user);
+            return user;
         } catch (error) {
-            done(error, false);
+            throw new InternalServerError('인증 중 에러가 발생하였습니다.');
         }
     }
 }

--- a/src/modules/auth/strategies/kakao.strategy.ts
+++ b/src/modules/auth/strategies/kakao.strategy.ts
@@ -15,11 +15,7 @@ export class KakaoStrategy extends PassportStrategy(Strategy) {
         });
     }
 
-    async validate(
-        accessToken: string,
-        refreshToken: string,
-        profile: Profile,
-    ): Promise<any> {
+    async validate(accessToken: string, refreshToken: string, profile: Profile): Promise<any> {
         try {
             const { _json } = profile;
             const user = {


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #183 

## ✅ 작업 내용

- 환경변수 `CORS_ORIGIN`에 여러 origin을 설정할 수 있도록 main.ts 수정
- `auth/kakao?redirect_url=http://localhost:3000` 이런 식으로 `redirect_url`이라는 이름으로 파라미터를 담아서 보냈을 때 해당 url이 화이트리스트라면 해당 url로 리다이렉트 됨.
- 파라미터의 url이 화이트리스트에 존재하지 않거나 파라미터를 생략할 경우, .env에 설정된 디폴트 값으로 리다이렉트 됨.

## 📸 스크린샷
**[redirect_url 있을 때]**
<img width="995" height="72" alt="image" src="https://github.com/user-attachments/assets/21ba177a-0691-42ce-997d-b7db979bb16d" />
<img width="826" height="82" alt="image" src="https://github.com/user-attachments/assets/3dd7fca0-eb8a-438f-a2a8-95ddbb8faa20" />

**[default]**
<img width="731" height="71" alt="image" src="https://github.com/user-attachments/assets/f7f7e4ee-104b-481e-8f00-8800deb684fe" />
<img width="763" height="57" alt="image" src="https://github.com/user-attachments/assets/d8d1d43a-1239-4bd8-b678-5503fef60e7b" />

## 📎 기타 참고사항

- 프론트 측에서 전달한 정보를 콜백 후에도 사용해야 하기 때문에 세션 라이브러리를 설치 및 사용하였습니다.
- 기존의 `CLIENT_REDIRECT_URL`을 `CLIENT_REDIRECT_URL`과 `CLIENT_REDIRECT_PATH`로 나누었습니다.
- 해당 로직은 프론트 배포가 완료되면 롤백시킬 예정입니다.
- 스크린샷에 서버도메인 노출되면 위험하려나요...? 위험할 것 같으면 스크린샷은 삭제하겠습니다.
