### PR TITLE
[Feat] 일정 삭제 기능 구현

### DIFF
--- a/src/modules/plans/dtos/delete-plan.dto.ts
+++ b/src/modules/plans/dtos/delete-plan.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeletePlanResponseDto {
+    @ApiProperty({
+        example: '일정이 성공적으로 삭제되었습니다.',
+        description: '삭제 성공 메시지',
+    })
+    message: string;
+
+    @ApiProperty({
+        example: 42,
+        description: '삭제된 일정 ID',
+    })
+    planId: number;
+
+    static from(planId: number) {
+        const dto = new DeletePlanResponseDto();
+        dto.message = '일정이 성공적으로 삭제되었습니다.';
+        dto.planId = planId;
+        return dto;
+    }
+}

--- a/src/modules/plans/plans.controller.ts
+++ b/src/modules/plans/plans.controller.ts
@@ -1,4 +1,14 @@
-import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Req } from '@nestjs/common';
+import {
+    Body,
+    Controller,
+    Delete,
+    Get,
+    Param,
+    ParseIntPipe,
+    Patch,
+    Post,
+    Req,
+} from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { PlansGateway } from './gateways/plans.gateway';
 import { Pulbic } from 'src/common/decorators/public.decorator';
@@ -11,6 +21,8 @@ import { PlanDetails } from './dtos/plan-details.dto';
 import { ErrorCode } from 'src/common/exceptions/errorcode.enum';
 import { PlansService } from './plans.service';
 import { ProjectForbiddenException } from 'src/common/exceptions/custom.errors';
+import { Transactional, TransactionalRequest } from 'src/common/decorators/transaction.decorator';
+import { DeletePlanResponseDto } from './dtos/delete-plan.dto';
 
 @ApiTags('Plans')
 @Controller('/plans')
@@ -42,5 +54,20 @@ export class PlansController {
         const check = await this.plansService.checkPermission(userId, planId);
         if (!check) throw new ProjectForbiddenException();
         return this.plansService.getDetails(planId);
+    }
+
+    @ApiOperation({
+        summary: '일정 삭제 API',
+        description: 'planId에 해당하는 일정을 삭제하는 API입니다.',
+    })
+    @ApiCommonResponse(DeletePlanResponseDto)
+    @Transactional()
+    @Delete('/:planId')
+    async deletePlan(
+        @Req() req: TransactionalRequest,
+        @User('id') userId: number,
+        @Param('planId', ParseIntPipe) planId: number
+    ): Promise<DeletePlanResponseDto> {
+        return await this.plansService.deletePlan(req.queryRunner, userId, planId);
     }
 }

--- a/src/modules/plans/plans.service.ts
+++ b/src/modules/plans/plans.service.ts
@@ -11,6 +11,7 @@ import {
 } from 'src/common/exceptions/custom.errors';
 import { ProjectsService } from '../projects/projects.service';
 import { CreatePlanResponse } from './dtos/create-plan.dto';
+import { DeletePlanResponseDto } from './dtos/delete-plan.dto';
 
 @Injectable()
 export class PlansService {
@@ -79,5 +80,34 @@ export class PlansService {
         } catch (err) {
             throw new PlanTransactionException();
         }
+    }
+
+    async deletePlan(
+        qr: QueryRunner,
+        userId: number,
+        planId: number
+    ): Promise<DeletePlanResponseDto> {
+        // 1. planId에 해당하는 plan 조회
+        const plan = await qr.manager.findOne(Plan, {
+            where: { id: planId },
+            relations: ['project'],
+        });
+        if (!plan)
+            throw new PlanNotFoundException({
+                planId: planId,
+            });
+
+        // 2. 사용자의 삭제 권한 검사
+        const checkUserIsMember = await this.projectsService.checkProjectMember(
+            userId,
+            plan.project.id
+        );
+        if (!checkUserIsMember) {
+            throw new ProjectForbiddenException();
+        }
+
+        // 3. 일정 삭제
+        await qr.manager.delete(Plan, planId);
+        return DeletePlanResponseDto.from(planId);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #178 

## ✅ 작업 내용

- 일정 삭제 기능 구현
- 트랜잭션 적용

## 📸 스크린샷
**[성공 200]**
<img width="862" height="602" alt="image" src="https://github.com/user-attachments/assets/34e16616-1c6a-46a4-bbfa-03e9d2549fc9" />

**[PLAN_NOT_FOUND]**
<img width="887" height="706" alt="image" src="https://github.com/user-attachments/assets/9bc80c2b-fb95-4a17-bb41-e5bfaed4b3b1" />

**[삭제 권한 없음]**
<img width="867" height="650" alt="image" src="https://github.com/user-attachments/assets/1df266fc-3d82-485e-9032-1a435a6ddf38" />

## 📎 기타 참고사항

- 일정의 삭제 기준에 대해 자세히 논의할 필요가 있음. (ex. 일정 상세 페이지 내에 사용자가 존재할 경우 삭제를 못하게 할 것인지 아니면 삭제 시 강제로 내쫓을 것인지)
- 게이트웨이 구현 이후 브로드캐스트 로직 추가가 필요함.
