### PR TITLE
[Feat] 마스터 포트폴리오 조회 및 업데이트 API 구현

### DIFF
--- a/src/common/enums/answer-type.enum.ts
+++ b/src/common/enums/answer-type.enum.ts
@@ -1,0 +1,4 @@
+export enum AnswerType {
+    YES = 'YES',
+    NO = 'NO',
+}

--- a/src/infra/llm/llm.service.ts
+++ b/src/infra/llm/llm.service.ts
@@ -160,7 +160,7 @@ export class LLMService {
         try {
             responseJsonData = JSON.parse(responseData.choices[0].message.content);
         } catch (e) {
-            // 별도 처리 필요
+            // 별도 처리 필요 (파싱 에러가 발생하면 이 에러가 발생함. Bad control character in string literal in JSON at position ~)
             throw new InternalServerErrorException(`Failed to parse response: ${e.message}`);
         }
 

--- a/src/modules/master-portfolios/dtos/question.dto.ts
+++ b/src/modules/master-portfolios/dtos/question.dto.ts
@@ -1,6 +1,8 @@
 import { QuestionType } from 'src/common/enums/question-type.enum';
 import { Questions } from '../entities/questions.entity';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNumber, IsOptional, IsString } from 'class-validator';
+import { AnswerType } from 'src/common/enums/answer-type.enum';
 
 export class QuestionResponseDto {
     @ApiProperty({ example: 1, description: '질문 ID' })
@@ -13,18 +15,46 @@ export class QuestionResponseDto {
     questionType: QuestionType;
 
     @ApiProperty({ required: false })
-    answer?: string;
+    @IsOptional()
+    @IsEnum(AnswerType)
+    answer?: AnswerType;
 
     @ApiProperty({ required: false })
+    @IsOptional()
+    @IsString()
     reason?: string;
 
     static from(question: Questions): QuestionResponseDto {
         const dto = new QuestionResponseDto();
         dto.question = question.question;
-        dto.answer = question.answer || '';
+        dto.answer = question.answer as AnswerType;
         dto.reason = question.reason || '';
         dto.questionType = question.questionType;
         dto.questionId = question.questionId;
         return dto;
     }
+}
+
+export class UpdateQuestionDto {
+    @IsNumber()
+    @ApiProperty({ example: 1, description: '질문 ID' })
+    questionId: number;
+
+    @IsEnum(AnswerType)
+    @IsOptional()
+    @ApiProperty({
+        enum: AnswerType,
+        required: false,
+        description: '답변 (YES, NO)',
+        example: AnswerType.YES,
+    })
+    answer?: AnswerType;
+    @IsString()
+    @IsOptional()
+    @ApiProperty({
+        required: false,
+        description: 'TEXT 타입이거나 답이 NO일 때, 입력 받는 답변 사유',
+        example: '답변 사유가 필요할 때 입력하면 됩니다.',
+    })
+    reason?: string;
 }

--- a/src/modules/master-portfolios/entities/questions.entity.ts
+++ b/src/modules/master-portfolios/entities/questions.entity.ts
@@ -2,6 +2,7 @@ import { QuestionType } from 'src/common/enums/question-type.enum';
 import { Column, Entity, ManyToOne, Unique } from 'typeorm';
 import { MasterPortfolio } from './master-portfolios.entity';
 import { BaseEntity } from 'src/common/entities/base.entity';
+import { AnswerType } from 'src/common/enums/answer-type.enum';
 
 @Entity()
 @Unique(['questionId', 'masterPortfolio'])
@@ -15,7 +16,11 @@ export class Questions extends BaseEntity {
     questionType: QuestionType;
     @Column()
     question: string;
-    @Column({ nullable: true })
+    @Column({
+        type: 'enum',
+        enum: AnswerType,
+        nullable: true,
+    })
     answer: string;
     @Column({ length: 300, nullable: true })
     reason: string;

--- a/src/modules/master-portfolios/master-portfolios.controller.ts
+++ b/src/modules/master-portfolios/master-portfolios.controller.ts
@@ -24,7 +24,7 @@ import {
     ApiCommonResponseArray,
     ApiCommonResponseWithPagination,
 } from 'src/common/response/swagger-response.helper';
-import { QuestionResponseDto } from './dtos/question-response.dto';
+import { QuestionResponseDto, UpdateQuestionDto } from './dtos/question.dto';
 import { MasterPortfolioResponseDto } from './dtos/master-portfolio-response.dto';
 import { DateCursor } from 'src/common/dtos/date-cursor.dto';
 import { MasterPortfolioAIResponseDto } from './dtos/master-portfolio-ai-response.dto';
@@ -99,6 +99,35 @@ export class MasterPortfoliosController {
             userId,
             portfolioId,
             createQuestionsDto.recordIdList
+        );
+    }
+
+    @ApiOperation({
+        summary: '마스터 포트폴리오 질문 조회 API',
+        description: '프로젝트의 마스터 포트폴리오 질문을 조회합니다.',
+    })
+    @Get(':portfolioId/questions')
+    async getQuestions(@Param('portfolioId', ParseIntPipe) portfolioId: number) {
+        return this.masterPortfoliosService.getQuestions(portfolioId);
+    }
+
+    @ApiOperation({
+        summary: '마스터 포트폴리오 질문(답변) 업데이트 API',
+        description: '프로젝트의 마스터 포트폴리오 질문에 대한 답변을 업데이트합니다.',
+    })
+    @ApiBody({ type: UpdateQuestionDto, isArray: true })
+    @Transactional()
+    @Patch(':portfolioId/questions')
+    async updateQuestions(
+        @Req() req: TransactionalRequest,
+        @Param('portfolioId', ParseIntPipe) portfolioId: number,
+        @Body(new ParseArrayPipe({ items: UpdateQuestionDto, optional: true }))
+        questions: UpdateQuestionDto[]
+    ) {
+        return this.masterPortfoliosService.updateQuestions(
+            req.queryRunner,
+            portfolioId,
+            questions
         );
     }
 

--- a/src/modules/master-portfolios/master-portfolios.controller.ts
+++ b/src/modules/master-portfolios/master-portfolios.controller.ts
@@ -106,6 +106,7 @@ export class MasterPortfoliosController {
         summary: '마스터 포트폴리오 질문 조회 API',
         description: '프로젝트의 마스터 포트폴리오 질문을 조회합니다.',
     })
+    @ApiParam({ name: 'portfolioId', type: Number, description: '포트폴리오 ID' })
     @Get(':portfolioId/questions')
     async getQuestions(@Param('portfolioId', ParseIntPipe) portfolioId: number) {
         return this.masterPortfoliosService.getQuestions(portfolioId);
@@ -116,6 +117,7 @@ export class MasterPortfoliosController {
         description: '프로젝트의 마스터 포트폴리오 질문에 대한 답변을 업데이트합니다.',
     })
     @ApiBody({ type: UpdateQuestionDto, isArray: true })
+    @ApiParam({ name: 'portfolioId', type: Number, description: '포트폴리오 ID' })
     @Transactional()
     @Patch(':portfolioId/questions')
     async updateQuestions(

--- a/src/modules/master-portfolios/master-portfolios.service.ts
+++ b/src/modules/master-portfolios/master-portfolios.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { BadRequestException, Injectable, InternalServerErrorException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Questions } from './entities/questions.entity';
 import { In, QueryRunner, Repository } from 'typeorm';
@@ -15,7 +15,7 @@ import {
     MasterPortfolioNotFoundException,
     ProjectNotFoundException,
 } from 'src/common/exceptions/custom.errors';
-import { QuestionResponseDto } from './dtos/question-response.dto';
+import { QuestionResponseDto, UpdateQuestionDto } from './dtos/question.dto';
 import { QuestionType } from 'src/common/enums/question-type.enum';
 import { MasterPortfolioRequestDto } from './dtos/master-portfolio-request.dto';
 import { UserMasterPortfoliosResponseDto } from './dtos/user-master-portfolios-response.dto';
@@ -218,6 +218,72 @@ export class MasterPortfoliosService {
         );
 
         return questionEntities;
+    }
+
+    // 마스터 포트폴리오 질문 조회
+    async getQuestions(portfolioId: number) {
+        const questions = await this.questionsRepository.find({
+            where: { masterPortfolio: { id: portfolioId } },
+            order: { questionId: 'ASC' },
+        });
+        if (questions.length === 0) {
+            throw new Error('No questions found for this master portfolio');
+        }
+
+        return questions;
+    }
+
+    // TODO: 커스텀 에러 추가
+    // 마스터 포트폴리오 질문(답변) 업데이트
+    async updateQuestions(qr: QueryRunner, portfolioId: number, questions: UpdateQuestionDto[]) {
+        for (const q of questions) {
+            const questionId = q.questionId;
+            const questionExists = await qr.manager.findOne(Questions, {
+                where: { questionId, masterPortfolio: { id: portfolioId } },
+            });
+            if (!questionExists) {
+                // questionId+portfolioId가 존재하지 않을 때
+                throw new BadRequestException(
+                    `Question with ID ${questionId} does not exist for portfolio ${portfolioId}`
+                );
+            }
+
+            const questionType = questionExists.questionType;
+            if (questionType === QuestionType.YES_NO) {
+                if (q.answer) {
+                    await qr.manager.update(
+                        Questions,
+                        { questionId, masterPortfolio: { id: portfolioId } },
+                        {
+                            answer: q.answer,
+                            reason: q.reason,
+                        }
+                    );
+                } else {
+                    throw new BadRequestException(
+                        `Answer is required for question type ${QuestionType.YES_NO} with ID ${questionId}`
+                    );
+                }
+            } else if (questionType === QuestionType.TEXT) {
+                // answer가 있으면 안됨
+                if (q.answer) {
+                    throw new BadRequestException(
+                        `Answer is not allowed for question type ${QuestionType.TEXT} with ID ${questionId}`
+                    );
+                }
+                await qr.manager.update(
+                    Questions,
+                    { questionId, masterPortfolio: { id: portfolioId } },
+                    {
+                        reason: q.reason,
+                    }
+                );
+            }
+        }
+        return await qr.manager.find(Questions, {
+            where: { masterPortfolio: { id: portfolioId } },
+            order: { questionId: 'ASC' },
+        });
     }
 
     // 마스터 포트폴리오 AI 생성

--- a/src/modules/master-portfolios/master-portfolios.service.ts
+++ b/src/modules/master-portfolios/master-portfolios.service.ts
@@ -227,7 +227,7 @@ export class MasterPortfoliosService {
             order: { questionId: 'ASC' },
         });
         if (questions.length === 0) {
-            throw new Error('No questions found for this master portfolio');
+            throw new BadRequestException('생성된 질문이 없습니다. 먼저 질문을 생성해주세요.');
         }
 
         return questions;
@@ -297,6 +297,16 @@ export class MasterPortfoliosService {
             throw new MasterPortfolioNotFoundException();
         }
 
+        // 질문이 생성된 상태인지 확인합니다.
+        const checkQuestions = await qr.manager.findOne(Questions, {
+            where: { masterPortfolio: { id: portfolioId } },
+        });
+        if (!checkQuestions) {
+            throw new BadRequestException(
+                '마스터 포트폴리오 AI 생성을 하기 위해서는 질문이 먼저 생성되어야 합니다.'
+            );
+        }
+
         // 프로젝트 ID를 가져옵니다.
         const projectId = masterPortfolio.project.id;
 
@@ -338,6 +348,19 @@ export class MasterPortfoliosService {
             keyAchievement: generatedPortfolio.keyAchievement,
             insight: generatedPortfolio.insight,
         });
+
+        // TODO: 직접작성 기능을 도입하는 시점에는 해당 코드 삭제
+        // 생성된 결과를 마스터 포트폴리오 엔티티에도 저장합니다.
+        qr.manager.update(
+            MasterPortfolio,
+            { id: portfolioId },
+            {
+                detailInfo: generatedPortfolio.detailInfo,
+                assignedTask: generatedPortfolio.assignedTask,
+                keyAchievement: generatedPortfolio.keyAchievement,
+                insight: generatedPortfolio.insight,
+            }
+        );
 
         try {
             await qr.manager.save(MasterPortfolioAI, createdPortfolio);

--- a/src/modules/portfolio-corrections/portfolio-corrections.service.ts
+++ b/src/modules/portfolio-corrections/portfolio-corrections.service.ts
@@ -68,13 +68,13 @@ export class PortfolioCorrectionsService {
         selectedProjects: number[]
     ) {
         const dummyData = await this.promptLoader.load('dummy-correction.json');
-          
+
         // 프로젝트 최대 선택 개수 6개로 제한
         if (selectedProjects.length > 6) {
             // TODO: 커스텀 에러 생성 필요
             throw new InternalServerErrorException('프로젝트는 최대 6개까지 선택할 수 있습니다.');
         }
-          
+
         // correctionId에 해당하는 포트폴리오 첨삭 엔티티가 있는지
         const existCorrectionPortfolio = await qr.manager.findOne(PortfolioCorrection, {
             where: { id: correctionId, user: { id: userId } },

--- a/src/modules/projects/projects.service.ts
+++ b/src/modules/projects/projects.service.ts
@@ -669,7 +669,6 @@ export class ProjectsService {
         await qr.manager.save(UserProject, userProject);
     }
 
-    
     async getProjectMemberList(projectId: number): Promise<UserProfile[]> {
         const project = await this.projectRepository.findOne({ where: { id: projectId } });
         if (!project) throw new ProjectNotFoundException();


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #209 

## ✅ 작업 내용

- 마스터 포트폴리오 조회 및 업데이트 API 구현
- 질문 생성하기 전에 마스터 포트폴리오 결과 생성 시도하는 것 차단하기
- AI 생성 결과를 기존 AI 결과를 저장하는 테이블에만 저장하지 않고 MasterPortfolio 테이블에도 저장

## 📸 스크린샷

- 조회
  <img width="507" height="550" alt="image" src="https://github.com/user-attachments/assets/f55abf71-9ba7-40d9-80ee-d73aa56e1916" />
- 업데이트 (YES_NO 타입에 answer를 빼먹은 경우)
  <img width="486" height="539" alt="image" src="https://github.com/user-attachments/assets/06e31200-468f-4679-a7ab-8ba5dd38de00" />
- 업데이트 (TEXT 타입에 answer를 넣은 경우)
  <img width="484" height="542" alt="image" src="https://github.com/user-attachments/assets/0c3acb64-495a-4b23-8ccc-39fe567aa409" />
- 업데이트 성공
  <img width="467" height="581" alt="image" src="https://github.com/user-attachments/assets/fc066e27-f0d0-41d5-b15d-29deed84aa3b" />

- 시도 차단
  <img width="494" height="541" alt="image" src="https://github.com/user-attachments/assets/3c29b20d-0000-46f1-8201-c9d43d2d3948" />
- 저장
  <img width="553" height="66" alt="image" src="https://github.com/user-attachments/assets/f28cb238-e3a5-4ea3-8b9c-f97ef0031213" />

## 📎 기타 참고사항

- 커스텀 에러 처리 추가하기
- DB 설계 방식과 업데이트 구현 로직 점검하기
