### PR TITLE
[Feat] 프로젝트 별 사용자 권한 조회 기능 구현

### DIFF
--- a/src/modules/auth/guards/project-member.guard.ts
+++ b/src/modules/auth/guards/project-member.guard.ts
@@ -1,0 +1,14 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { ProjectsService } from 'src/modules/projects/projects.service';
+
+@Injectable()
+export class ProjectMemberGuard implements CanActivate {
+    constructor(private readonly projectService: ProjectsService) {}
+
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+        const request = context.switchToHttp().getRequest();
+        const userId = request.userId;
+        const projectId = Number(request.params.projectId);
+        return await this.projectService.checkProjectMember(userId, projectId);
+    }
+}

--- a/src/modules/projects/projects.controller.ts
+++ b/src/modules/projects/projects.controller.ts
@@ -294,12 +294,24 @@ export class ProjectsController {
 
     @ApiOperation({
         summary: '프로젝트 참여자 리스트 조회',
-        description: '프로젝에 참여자 리스트를 조회합니다.',
+        description: '프로젝트에 참여자 리스트를 조회합니다.',
     })
     @ApiParam({ name: 'projectId', type: Number, description: '프로젝트 ID' })
     @ApiOkResponse({ type: UserProfile, isArray: true })
     @Get('/:projectId/members')
     async getProjectMemberList(@Param('projectId', ParseIntPipe) projectId: number) {
         return await this.projectsService.getProjectMemberList(projectId);
+    }
+
+    @ApiOperation({
+        summary: '사용자의 프로젝트 권한 조회 API',
+        description: '사용자의 프로젝트 권한을 조회합니다.',
+    })
+    @Get('/:projectId/my-permission')
+    async getUserProjectPermission(
+        @User('id') userId: number,
+        @Param('projectId', ParseIntPipe) projectId: number
+    ) {
+        return await this.projectsService.getUserPermissionOfProject(userId, projectId);
     }
 }

--- a/src/modules/projects/projects.controller.ts
+++ b/src/modules/projects/projects.controller.ts
@@ -10,6 +10,7 @@ import {
     ParseIntPipe,
     Req,
     ValidationPipe,
+    UseGuards,
 } from '@nestjs/common';
 import { ProjectsService } from './projects.service';
 import { CreateProjectDto, CreateProjectResponseDto } from './dtos/create-project.dto';
@@ -36,6 +37,7 @@ import { PlansService } from '../plans/plans.service';
 import { TeamCalenderResponseDto } from './dtos/team-calender-response.dto';
 import { CalenderQueryDto } from 'src/common/dtos/calender-date-query.dto';
 import { UserProfile } from '../../common/dtos/user-profile.dto';
+import { ProjectMemberGuard } from '../auth/guards/project-member.guard';
 
 @ApiTags('Projects')
 @Controller('/projects')
@@ -264,6 +266,7 @@ export class ProjectsController {
             '프로젝트 별 팀 캘린더를 조회하는 API, 캘린더의 시작 날짜와 마지막 날짜를 입력해주세요.',
     })
     @ApiCommonResponseArray(TeamCalenderResponseDto)
+    @UseGuards(ProjectMemberGuard)
     @Get('/:projectId/plans')
     async getTeamCalender(
         @User('id') userId: number,
@@ -272,7 +275,7 @@ export class ProjectsController {
     ) {
         const startDate = query.startDate;
         const endDate = query.endDate;
-        return await this.projectsService.getTeamCalender(userId, projectId, startDate, endDate);
+        return await this.projectsService.getTeamCalender(projectId, startDate, endDate);
     }
 
     @ApiOperation({

--- a/src/modules/projects/projects.service.ts
+++ b/src/modules/projects/projects.service.ts
@@ -614,6 +614,18 @@ export class ProjectsService {
         return !!mapping;
     }
 
+    // 사용자의 프로젝트 권한 조회
+    async getUserPermissionOfProject(userId: number, projectId: number) {
+        const userProject = await this.userProjectRepository.findOne({
+            where: {
+                user: { id: userId },
+                project: { id: projectId },
+            },
+        });
+        if (!userProject) throw new ProjectForbiddenException();
+        return { permission: userProject.permission };
+    }
+
     // 참여코드로 프로젝트 id 조회
     private async getProjectByInviteCode(inviteCode: string) {
         const codeKey = `invite:${inviteCode}`;

--- a/src/modules/projects/projects.service.ts
+++ b/src/modules/projects/projects.service.ts
@@ -514,7 +514,7 @@ export class ProjectsService {
         return UpdateProfileResponseDto.fromEntity(users);
     }
 
-    async getTeamCalender(userId: number, projectId: number, startDate: string, endDate: string) {
+    async getTeamCalender(projectId: number, startDate: string, endDate: string) {
         //검색 범위 제한 - 최대 31일
         const start = new Date(startDate);
         const end = new Date(endDate);
@@ -528,8 +528,6 @@ export class ProjectsService {
                 endDate: endDate,
             });
         }
-        // 사용자 조회 권한 체크
-        await this.checkProjectMember(userId, projectId);
 
         //팀캘린더 조회
         //1. tasks 카드 조회


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #221 

## ✅ 작업 내용

- 사용자의 프로젝트 권한 조회
- 프로젝트 별 사용자 접근 권한을 체크하는 커스텀 가드 추가

## 📸 스크린샷
**[성공 200]**
<img width="867" height="363" alt="image" src="https://github.com/user-attachments/assets/b1f2bbe6-e1a1-4120-86a3-9292cd44d78c" />
<img width="847" height="371" alt="image" src="https://github.com/user-attachments/assets/9a09f8bf-f113-4596-92eb-a7601f7ee2ef" />

**[에러 403]**
<img width="857" height="437" alt="image" src="https://github.com/user-attachments/assets/ddc3a867-575d-410c-b623-a71820700955" />

## 📎 기타 참고사항
- `projectId`를 파라미터로 받는 API에서만 사용 가능합니다. `@UserGuard(ProjectMember)` 형태로 사용 가능해요~