### PR TITLE
[Feat] 마스터 포트폴리오 AI 생성 결과 구조 검사 기능 추가

### DIFF
--- a/src/modules/master-portfolios/services/master-portfolios.service.ts
+++ b/src/modules/master-portfolios/services/master-portfolios.service.ts
@@ -61,6 +61,40 @@ function getPeriod(createdAt: Date, completedAt: Date): string {
     return period.join(' ');
 }
 
+type MasterPortfolioContentCheckResult = {
+    [K in keyof MasterPortfolioOutput]?: boolean;
+};
+
+function checkMasterPortfolioContentStructure(
+    data: MasterPortfolioOutput
+): MasterPortfolioContentCheckResult {
+    const results: MasterPortfolioContentCheckResult = {};
+
+    // 프로젝트명 검사 : 1~20자
+    results.projectName =
+        typeof data.projectName === 'string' &&
+        data.projectName.length > 0 &&
+        data.projectName.length <= 20;
+    // 상세정보 검사 : 최소 4개 이상의 리스트 (-로 시작)
+    results.detailInfo =
+        typeof data.detailInfo === 'string' && (data.detailInfo.match(/^- /gm)?.length ?? 0) >= 4;
+    // 담당업무 검사 : [섹션명]으로 시작하는 구간 1개 이상, 각 섹션에 -로 시작하는 리스트 1개 이상
+    // TODO: 구조(순서)까지는 검사하지 못하는 문제가 있음. 개선해볼 것
+    results.assignedTask =
+        typeof data.assignedTask === 'string' &&
+        /\[.+\]/.test(data.assignedTask) &&
+        (data.assignedTask.match(/^- /gm)?.length ?? 0) >= 1;
+    // 주요성과 검사 : -로 시작하는 리스트 2개 이상
+    results.keyAchievement =
+        typeof data.keyAchievement === 'string' &&
+        (data.keyAchievement.match(/^- /gm)?.length ?? 0) >= 2;
+    // 배운점 검사 : -로 시작하는 문장 2개 이상
+    results.insight =
+        typeof data.insight === 'string' && (data.insight.match(/^- /gm)?.length ?? 0) >= 2;
+
+    return results;
+}
+
 @Injectable()
 export class MasterPortfoliosService {
     constructor(
@@ -339,7 +373,18 @@ export class MasterPortfoliosService {
                 { status: MasterPortfolioStatus.NEED_ANSWERS }
             );
 
-            throw new InternalServerErrorException('Failed to generate master portfolio');
+            throw new InternalServerErrorException(
+                '마스터 포트폴리오 AI 생성에 실패했습니다. 다시 시도해주세요.'
+            );
+        }
+
+        // 생성된 JSON 값 구조 검사
+        const checkResult = checkMasterPortfolioContentStructure(generatedPortfolio);
+        const isValid = Object.values(checkResult).every((value) => value === true);
+        if (!isValid) {
+            throw new InternalServerErrorException(
+                '생성된 마스터 포트폴리오의 구조가 유효하지 않습니다.'
+            );
         }
 
         // 생성된 마스터 포트폴리오를 데이터베이스에 저장합니다.

--- a/src/modules/portfolio-corrections/services/portfolio-corrections.service.ts
+++ b/src/modules/portfolio-corrections/services/portfolio-corrections.service.ts
@@ -80,7 +80,9 @@ export class PortfolioCorrectionsService {
 
         // 프로젝트 최대 선택 개수 제한
         if (selectedProjects.length > parseInt(process.env.MAX_SELECTED_PROJECTS || '6', 10)) {
-            throw new InternalServerErrorException(`프로젝트는 최대 ${process.env.MAX_SELECTED_PROJECTS || '6'}개까지 선택할 수 있습니다.`);
+            throw new InternalServerErrorException(
+                `프로젝트는 최대 ${process.env.MAX_SELECTED_PROJECTS || '6'}개까지 선택할 수 있습니다.`
+            );
         }
 
         // correctionId에 해당하는 포트폴리오 첨삭 엔티티가 있는지


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #217 

## ✅ 작업 내용

- 정규표현식으로 json 데이터 안에 담겨있는 값의 구조를 검사

## 📸 스크린샷

- 구조 검사를 통과하지 못한 경우
  <img width="488" height="547" alt="화면 캡처 2025-08-10 011104" src="https://github.com/user-attachments/assets/f744e5a0-b21a-46a0-a659-fca48ac51894" />

## 📎 기타 참고사항

- 담당업무 부분에서 [섹션명]과 "- " 줄 표시의 순서는 검사하지 못함. (아마 AI가 이건 틀리지 않을 것이기 때문에 일단은 PASS)
