### PR TITLE
[Feat] 마스터 포트폴리오 실제 데이터 사용

### DIFF
--- a/src/common/utils/get-period.ts
+++ b/src/common/utils/get-period.ts
@@ -1,0 +1,35 @@
+export function getPeriod(createdAt: Date, completedAt: Date): string {
+    createdAt = typeof createdAt === 'string' ? new Date(createdAt) : createdAt;
+    completedAt = typeof completedAt === 'string' ? new Date(completedAt) : completedAt;
+
+    let years = completedAt.getFullYear() - createdAt.getFullYear();
+    let months = completedAt.getMonth() - createdAt.getMonth();
+    let days = completedAt.getDate() - createdAt.getDate();
+
+    if (years === 0 && months === 0) {
+        // 같은 해, 같은 달인 경우 일 차이만 계산
+        if (days === 0) {
+            return '0일';
+        }
+        return `${days}일`;
+    }
+
+    // 월 차이가 음수인 경우 보정
+    if (days < 0) {
+        months -= 1;
+        const prevMonth = new Date(completedAt.getFullYear(), completedAt.getMonth(), 0);
+        days += prevMonth.getDate();
+    }
+    // 연 차이가 음수인 경우 보정
+    if (months < 0) {
+        years -= 1;
+        months += 12;
+    }
+
+    // 0인 단위는 표시하지 않음
+    const period: string[] = [];
+    if (years > 0) period.push(`${years}년`);
+    if (months > 0) period.push(`${months}개월`);
+    if (days > 0) period.push(`${days}일`);
+    return period.join(' ');
+}

--- a/src/config/typeorm.config.ts
+++ b/src/config/typeorm.config.ts
@@ -13,6 +13,5 @@ export const typeORMConfig = (configService: ConfigService): TypeOrmModuleOption
         database: configService.get<string>('DB_NAME'),
         entities: [__dirname + '/../modules/**/*.entity.{ts,js}'],
         synchronize: true, //개발단계에서만 허용
-        logging: ['query', 'error'],
     };
 };

--- a/src/infra/llm/llm.service.ts
+++ b/src/infra/llm/llm.service.ts
@@ -88,7 +88,6 @@ export class LLMService {
                 baseURL: this.baseURL,
             },
         });
-        console.log(process.env.LLM_QUESTION_MODEL);
 
         this.masterPortfolioLLM = new ChatOpenAI({
             model:
@@ -165,12 +164,11 @@ export class LLMService {
     }
 
     // 마스터 포트폴리오 AI 생성
-    async generateMasterPortfolio(projectData: any) {
+    async generateMasterPortfolio(questionData: any, projectData: string) {
         // 마스터 포트폴리오 프롬프트를 로드합니다.
         let masterPortfolioPromptText: string;
         try {
             masterPortfolioPromptText = await this.promptLoader.load('master-portfolio.prompt.md');
-            projectData = await this.promptLoader.load('dummy-input.json');
         } catch (e) {
             throw new PromptLoadingException('master-portfolio.prompt.md');
         }
@@ -185,6 +183,7 @@ export class LLMService {
 
         try {
             const masterPortfolioResult = await masterPortfolioPrompt.pipe(structuredLLM).invoke({
+                questionData: questionData,
                 projectData: projectData,
             });
 

--- a/src/infra/llm/llm.service.ts
+++ b/src/infra/llm/llm.service.ts
@@ -1,9 +1,6 @@
 import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { Question } from '../../common/types/question.type';
-import { QuestionResponseFormat } from './formats/question-response.format';
 import { PromptLoader } from 'src/common/utils/prompt.loader';
-import { MasterPortfolioResponseFormat } from './formats/master-portfolio-response.format';
-import { MasterPortfolioOutput } from 'src/common/types/master-portfolio.type';
 import { PromptLoadingException } from 'src/common/exceptions/custom.errors';
 import { ChatOpenAI } from '@langchain/openai';
 import { ChatPromptTemplate } from '@langchain/core/prompts';

--- a/src/infra/llm/llm.service.ts
+++ b/src/infra/llm/llm.service.ts
@@ -14,6 +14,7 @@ import { QueryRunner } from 'typeorm';
 import { PortfolioCorrection } from 'src/modules/portfolio-corrections/entities/portfolio-correction.entity';
 import { Questions, questionSchema } from './schemas/questions.schema';
 import { MasterPortfolio, masterPortfolioSchema } from './schemas/master-portfolio.schema';
+import { ProjectData } from 'src/modules/master-portfolios/types/project-data.interface';
 
 function processLLMError(error: any) {
     // JSON 파싱 실패
@@ -116,10 +117,15 @@ export class LLMService {
         try {
             questionPromptText = await this.promptLoader.load('question.prompt.md');
         } catch (e) {
-            throw new PromptLoadingException('question.prompt.md');
+            throw new PromptLoadingException('파일 로딩 실패 (question.prompt.md)');
         }
 
-        const questionPrompt = ChatPromptTemplate.fromTemplate(questionPromptText);
+        let questionPrompt: ChatPromptTemplate;
+        try {
+            questionPrompt = ChatPromptTemplate.fromTemplate(questionPromptText);
+        } catch (e) {
+            throw new PromptLoadingException('프롬프트 로딩 실패 (question.prompt.md)');
+        }
         const structuredLLM = this.questionLLM.withStructuredOutput<Questions>(questionSchema, {
             name: 'questions',
         });
@@ -164,16 +170,21 @@ export class LLMService {
     }
 
     // 마스터 포트폴리오 AI 생성
-    async generateMasterPortfolio(questionData: any, projectData: string) {
+    async generateMasterPortfolio(questionData: any, projectData: ProjectData) {
         // 마스터 포트폴리오 프롬프트를 로드합니다.
         let masterPortfolioPromptText: string;
         try {
             masterPortfolioPromptText = await this.promptLoader.load('master-portfolio.prompt.md');
         } catch (e) {
-            throw new PromptLoadingException('master-portfolio.prompt.md');
+            throw new PromptLoadingException('파일 로딩 실패 (master-portfolio.prompt.md)');
         }
 
-        const masterPortfolioPrompt = ChatPromptTemplate.fromTemplate(masterPortfolioPromptText);
+        let masterPortfolioPrompt: ChatPromptTemplate;
+        try {
+            masterPortfolioPrompt = ChatPromptTemplate.fromTemplate(masterPortfolioPromptText);
+        } catch (e) {
+            throw new PromptLoadingException('프롬프트 로딩 실패 (master-portfolio.prompt.md)');
+        }
         const structuredLLM = this.masterPortfolioLLM.withStructuredOutput<MasterPortfolio>(
             masterPortfolioSchema,
             {
@@ -227,9 +238,15 @@ export class LLMService {
         try {
             correctionPromptText = await this.promptLoader.load('portfolio-correction.prompt.md');
         } catch (e) {
-            throw new PromptLoadingException('portfolio-correction.prompt.md');
+            throw new PromptLoadingException('파일 로딩 실패 (portfolio-correction.prompt.md)');
         }
-        const correctionPrompt = ChatPromptTemplate.fromTemplate(correctionPromptText);
+
+        let correctionPrompt: ChatPromptTemplate;
+        try {
+            correctionPrompt = ChatPromptTemplate.fromTemplate(correctionPromptText);
+        } catch (e) {
+            throw new PromptLoadingException('프롬프트 로딩 실패 (portfolio-correction.prompt.md)');
+        }
 
         const structuredLLM = this.correctionLLM.withStructuredOutput<Correction>(
             correctionSchema,

--- a/src/modules/master-portfolios/master-portfolios.controller.ts
+++ b/src/modules/master-portfolios/master-portfolios.controller.ts
@@ -67,11 +67,8 @@ export class MasterPortfoliosController {
     })
     @ApiParam({ name: 'portfolioId', type: Number, description: '포트폴리오 ID' })
     @Get(':portfolioId/status')
-    async getStatus(
-        @User('id') userId: number,
-        @Param('portfolioId', ParseIntPipe) portfolioId: number
-    ) {
-        return this.masterPortfoliosService.getStatus(userId, portfolioId);
+    async getStatus(@Param('portfolioId', ParseIntPipe) portfolioId: number) {
+        return this.masterPortfoliosService.getStatus(portfolioId);
     }
 
     @Post(':portfolioId/questions')

--- a/src/modules/master-portfolios/services/master-portfolios.service.ts
+++ b/src/modules/master-portfolios/services/master-portfolios.service.ts
@@ -12,7 +12,6 @@ import {
 } from '../dtos/master-portfolio-response.dto';
 import {
     AIGenerationAlreadyExists,
-    ForbiddenUserForMasterPortfolioException,
     MasterPortfolioAINotFoundException,
     MasterPortfolioDuplicateException,
     MasterPortfolioNotFoundException,
@@ -36,10 +35,8 @@ import { UserProject } from '../../projects/entities/userProjects.entity';
 import { SelectablePlanResponseDto } from '../dtos/selectable-plan.dto';
 import { MasterPortfolioStatus } from 'src/common/enums/master-portfolio-status.enum';
 import { getPeriod } from 'src/common/utils/get-period';
-
-type MasterPortfolioContentCheckResult = {
-    [K in keyof MasterPortfolioOutput]?: boolean;
-};
+import { MasterPortfolioContentCheckResult } from '../types/content-check.type';
+import { ProjectData } from '../types/project-data.interface';
 
 function checkMasterPortfolioContentStructure(
     data: MasterPortfolioOutput
@@ -51,24 +48,111 @@ function checkMasterPortfolioContentStructure(
     //     typeof data.projectName === 'string' &&
     //     data.projectName.length > 0 &&
     //     data.projectName.length <= 20;
+
     // 상세정보 검사 : 최소 4개 이상의 리스트 (-로 시작)
     results.detailInfo =
         typeof data.detailInfo === 'string' && (data.detailInfo.match(/^- /gm)?.length ?? 0) >= 4;
+
     // 담당업무 검사 : [섹션명]으로 시작하는 구간 1개 이상, 각 섹션에 -로 시작하는 리스트 1개 이상
     // TODO: 구조(순서)까지는 검사하지 못하는 문제가 있음. 개선해볼 것
     results.assignedTask =
         typeof data.assignedTask === 'string' &&
         /\[.+\]/.test(data.assignedTask) &&
         (data.assignedTask.match(/^- /gm)?.length ?? 0) >= 1;
+
     // 주요성과 검사 : -로 시작하는 리스트 2개 이상
     results.keyAchievement =
         typeof data.keyAchievement === 'string' &&
         (data.keyAchievement.match(/^- /gm)?.length ?? 0) >= 2;
+
     // 배운점 검사 : -로 시작하는 문장 2개 이상
     results.insight =
         typeof data.insight === 'string' && (data.insight.match(/^- /gm)?.length ?? 0) >= 2;
 
     return results;
+}
+
+async function getProjectData(
+    qr: QueryRunner,
+    userId: number,
+    masterPortfolioId: number,
+    projectId: number,
+    recordIdList?: number[]
+) {
+    // 1. 선택된 회의록 내용
+    let records: any[];
+    if (!recordIdList) {
+        const plans = await qr.manager.find(Plan, {
+            where: { masterPortfolioId: masterPortfolioId, project: { id: projectId } },
+            select: ['name', 'meetingRecords'],
+        });
+        records = plans.map((plan) => ({
+            name: plan.name,
+            meetingRecords: plan.meetingRecords,
+        }));
+    } else {
+        records = await qr.manager.find(Plan, {
+            where: { id: In(recordIdList) },
+            select: ['name', 'meetingRecords'],
+        });
+    }
+    // 2. 담당자로 지정된 모든 업무명
+    const tasks = await qr.manager.find(Task, {
+        where: { managers: { user: { id: userId } }, step: { project: { id: projectId } } },
+        select: ['name'],
+    });
+    // 3. 개인회고 내용
+    const personalRecall = await qr.manager.findOne(PersonalRecall, {
+        where: { user: { id: userId }, project: { id: projectId } },
+        select: ['id', 'collaborationProfile', 'memorableExperience', 'strengthsAndGrowth'],
+    });
+    // 4. 프로젝트명, 진행기간
+    const projectInfo = await qr.manager.findOne(Project, {
+        where: { id: projectId },
+        select: ['createdAt', 'completedAt', 'name'],
+    });
+    if (!projectInfo) {
+        throw new ProjectNotFoundException(`ID가 ${projectId}인 프로젝트를 찾을 수 없습니다.`);
+    }
+    const projectName: string = projectInfo.name; // 프로젝트명
+    const createdAt: Date = projectInfo.createdAt; // 2025-07-26T06:05:35.998Z, Date 객체
+    const completedAt: Date = projectInfo.completedAt || new Date(); // 완료일이 없으면 현재 시간으로 설정
+    const projectPeriod: string = getPeriod(createdAt, completedAt);
+
+    // 5. 분류 태그, 기여도
+    const masterPortfolioData = await qr.manager.findOne(MasterPortfolio, {
+        where: { id: masterPortfolioId },
+        select: ['category', 'contributionRate'],
+    });
+    if (!masterPortfolioData) {
+        throw new MasterPortfolioNotFoundException(
+            `ID가 ${masterPortfolioId}인 마스터 포트폴리오를 찾을 수 없습니다.`
+        );
+    }
+    const category: portfolioType = masterPortfolioData.category;
+    const contributionRate: number = masterPortfolioData.contributionRate;
+
+    // 6. 이름과 역할(role)
+    const userName = await qr.manager.findOne(User, {
+        where: { id: userId },
+        select: ['name'],
+    });
+    const role = await qr.manager.findOne(UserProject, {
+        where: { user: { id: userId }, project: { id: projectId } },
+        select: ['id', 'role'],
+    });
+
+    return {
+        records,
+        tasks,
+        personalRecall,
+        projectName,
+        category,
+        contributionRate,
+        userName: userName?.name || '',
+        role: role?.role || '',
+        projectPeriod,
+    };
 }
 
 @Injectable()
@@ -120,70 +204,19 @@ export class MasterPortfoliosService {
 
         // TODO: 가져오는 데이터가 많음, 정리할 것
         // 가져올 데이터
-        // 1. 선택된 회의록 내용
-        const records = await qr.manager.find(Plan, {
-            where: { id: In(recordIdList) },
-            select: ['name', 'meetingRecords'],
-        });
-        // 2. 담당자로 지정된 모든 업무명
-        const tasks = await qr.manager.find(Task, {
-            where: { managers: { user: { id: userId } }, step: { project: { id: projectId } } },
-            select: ['name'],
-        });
-        // 3. 개인회고 내용
-        const personalRecalls = await qr.manager.findOne(PersonalRecall, {
-            where: { user: { id: userId }, project: { id: projectId } },
-            select: ['id', 'collaborationProfile', 'memorableExperience', 'strengthsAndGrowth'],
-        });
-        // 4. 프로젝트명, 진행기간
-        const projectInfo = await qr.manager.findOne(Project, {
-            where: { id: projectId },
-            select: ['createdAt', 'completedAt', 'name'],
-        });
-        if (!projectInfo) {
-            throw new ProjectNotFoundException(`Project with ID ${projectId} not found`);
-        }
-        const projectName: string = projectInfo.name; // 프로젝트명
-        const createdAt: Date = projectInfo.createdAt; // 2025-07-26T06:05:35.998Z, Date 객체
-        const completedAt: Date = projectInfo.completedAt || new Date(); // 완료일이 없으면 현재 시간으로 설정
-        const projectPeriod: string = getPeriod(createdAt, completedAt);
-
-        // 5. 분류 태그, 기여도
-        const masterPortfolioData = await qr.manager.findOne(MasterPortfolio, {
-            where: { id: masterPortfolioId },
-            select: ['category', 'contributionRate'],
-        });
-        if (!masterPortfolioData) {
-            throw new MasterPortfolioNotFoundException(
-                `Master portfolio with ID ${masterPortfolioId} not found`
-            );
-        }
-        const category: string = masterPortfolioData.category;
-        const contributionRate: number = masterPortfolioData.contributionRate;
-
-        // 6. 이름과 역할(role)
-        const userName = await qr.manager.findOne(User, {
-            where: { id: userId },
-            select: ['name'],
-        });
-        const role = await qr.manager.findOne(UserProject, {
-            where: { user: { id: userId }, project: { id: projectId } },
-            select: ['id', 'role'],
-        });
+        const projectData = await getProjectData(qr, userId, masterPortfolioId, projectId);
 
         // TODO: inputData 형태 정리
         const inputData: string = JSON.stringify({
-            userName: userName?.name,
-            role: role?.role,
-            projectName: projectName,
-            projectPeriod: projectPeriod,
-            createdAt,
-            completedAt,
-            category,
-            contributionRate,
-            records,
-            tasks,
-            personalRecalls,
+            userName: projectData.userName,
+            role: projectData.role,
+            projectName: projectData.projectName,
+            projectPeriod: projectData.projectPeriod,
+            category: projectData.category,
+            contributionRate: projectData.contributionRate,
+            records: projectData.records,
+            tasks: projectData.tasks,
+            personalRecall: projectData.personalRecall,
         });
 
         // LLM을 호출하여 질문을 생성합니다.
@@ -209,7 +242,7 @@ export class MasterPortfoliosService {
                 questionEntities.push(QuestionResponseDto.from(savedQuestion));
             } catch (e) {
                 console.error(`질문 생성 중 오류 발생: ${e.message}`);
-                throw new InternalServerErrorException(`Failed to create question: ${e.message}`);
+                throw new InternalServerErrorException(`질문 생성 중 오류 발생: ${e.message}`);
             }
         }
 
@@ -324,76 +357,12 @@ export class MasterPortfoliosService {
 
         // 입력할 데이터 가져오기
         const questionData = await this.getQuestions(portfolioId);
-        let projectData: any;
-
-        const plans = await qr.manager.find(Plan, {
-            where: { masterPortfolioId: portfolioId, project: { id: projectId } },
-            select: ['name', 'meetingRecords'],
-        });
-        // 1. 선택된 회의록 내용
-        const records = plans.map((plan) => ({
-            name: plan.name,
-            meetingRecords: plan.meetingRecords,
-        }));
-        // 2. 담당자로 지정된 모든 업무명
-        const tasks = await qr.manager.find(Task, {
-            where: { managers: { user: { id: userId } }, step: { project: { id: projectId } } },
-            select: ['name'],
-        });
-        // 3. 개인회고 내용
-        const personalRecalls = await qr.manager.findOne(PersonalRecall, {
-            where: { user: { id: userId }, project: { id: projectId } },
-            select: ['id', 'collaborationProfile', 'memorableExperience', 'strengthsAndGrowth'],
-        });
-        // 4. 프로젝트명, 진행기간
-        const projectInfo = await qr.manager.findOne(Project, {
-            where: { id: projectId },
-            select: ['createdAt', 'completedAt', 'name'],
-        });
-        if (!projectInfo) {
-            throw new ProjectNotFoundException(`Project with ID ${projectId} not found`);
-        }
-        const projectName: string = projectInfo.name; // 프로젝트명
-        const createdAt: Date = projectInfo.createdAt; // 2025-07-26T06:05:35.998Z, Date 객체
-        const completedAt: Date = projectInfo.completedAt || new Date(); // 완료일이 없으면 현재 시간으로 설정
-        const projectPeriod: string = getPeriod(createdAt, completedAt);
-
-        // 5. 분류 태그, 기여도
-        const masterPortfolioData = await qr.manager.findOne(MasterPortfolio, {
-            where: { id: masterPortfolioId },
-            select: ['category', 'contributionRate'],
-        });
-        if (!masterPortfolioData) {
-            throw new MasterPortfolioNotFoundException(
-                `Master portfolio with ID ${masterPortfolioId} not found`
-            );
-        }
-        const category: string = masterPortfolioData.category;
-        const contributionRate: number = masterPortfolioData.contributionRate;
-
-        // 6. 이름과 역할(role)
-        const userName = await qr.manager.findOne(User, {
-            where: { id: userId },
-            select: ['name'],
-        });
-        const role = await qr.manager.findOne(UserProject, {
-            where: { user: { id: userId }, project: { id: projectId } },
-            select: ['id', 'role'],
-        });
-
-        projectData = JSON.stringify({
-            userName: userName?.name,
-            role: role?.role,
-            projectName: projectName,
-            projectPeriod: projectPeriod,
-            createdAt,
-            completedAt,
-            category,
-            contributionRate,
-            records,
-            tasks,
-            personalRecalls,
-        });
+        const projectData: ProjectData = await getProjectData(
+            qr,
+            userId,
+            masterPortfolioId,
+            projectId
+        );
 
         // 진행 상태를 `GENERATING`으로 업데이트합니다.
         await this.masterPortfolioRepository.update(
@@ -401,60 +370,70 @@ export class MasterPortfoliosService {
             { status: MasterPortfolioStatus.GENERATING }
         );
 
-        const generatedPortfolio: MasterPortfolioOutput =
-            await this.llmService.generateMasterPortfolio(questionData, projectData);
-        if (!generatedPortfolio) {
+        try {
+            const generatedPortfolio: MasterPortfolioOutput =
+                await this.llmService.generateMasterPortfolio(questionData, projectData);
+            if (!generatedPortfolio) {
+                // 실패 시, 상태를 이전으로 돌립니다.
+                await this.masterPortfolioRepository.update(
+                    { id: portfolioId },
+                    { status: MasterPortfolioStatus.NEED_ANSWERS }
+                );
+
+                throw new InternalServerErrorException(
+                    '마스터 포트폴리오 AI 생성에 실패했습니다. 다시 시도해주세요.'
+                );
+            }
+
+            console.log('생성된 마스터 포트폴리오:', generatedPortfolio);
+            // 생성된 JSON 값 구조 검사
+            const checkResult = checkMasterPortfolioContentStructure(generatedPortfolio);
+            const isValid = Object.values(checkResult).every((value) => value === true);
+            if (!isValid) {
+                throw new InternalServerErrorException(
+                    '생성된 마스터 포트폴리오의 구조가 유효하지 않습니다.'
+                );
+            }
+
+            // 생성된 마스터 포트폴리오를 데이터베이스에 저장합니다.
+            const createdPortfolio = qr.manager.create(MasterPortfolioAI, {
+                user: { id: userId },
+                project: { id: projectId },
+                detailInfo: generatedPortfolio.detailInfo,
+                assignedTask: generatedPortfolio.assignedTask,
+                keyAchievement: generatedPortfolio.keyAchievement,
+                insight: generatedPortfolio.insight,
+            });
+
+            // TODO: 직접작성 기능을 도입하는 시점에는 해당 코드 삭제
+            // 생성된 결과를 마스터 포트폴리오 엔티티에도 저장합니다.
+            qr.manager.update(
+                MasterPortfolio,
+                { id: portfolioId },
+                {
+                    detailInfo: generatedPortfolio.detailInfo,
+                    assignedTask: generatedPortfolio.assignedTask,
+                    keyAchievement: generatedPortfolio.keyAchievement,
+                    insight: generatedPortfolio.insight,
+                }
+            );
+
+            try {
+                await qr.manager.save(MasterPortfolioAI, createdPortfolio);
+            } catch (e) {
+                console.error(`마스터 포트폴리오 AI 생성 중 오류 발생: ${e.message}`);
+                throw new InternalServerErrorException(
+                    `Failed to save master portfolio AI: ${e.message}`
+                );
+            }
+        } catch (error) {
             // 실패 시, 상태를 이전으로 돌립니다.
             await this.masterPortfolioRepository.update(
                 { id: portfolioId },
                 { status: MasterPortfolioStatus.NEED_ANSWERS }
             );
 
-            throw new InternalServerErrorException(
-                '마스터 포트폴리오 AI 생성에 실패했습니다. 다시 시도해주세요.'
-            );
-        }
-
-        console.log('생성된 마스터 포트폴리오:', generatedPortfolio);
-        // 생성된 JSON 값 구조 검사
-        const checkResult = checkMasterPortfolioContentStructure(generatedPortfolio);
-        const isValid = Object.values(checkResult).every((value) => value === true);
-        if (!isValid) {
-            throw new InternalServerErrorException(
-                '생성된 마스터 포트폴리오의 구조가 유효하지 않습니다.'
-            );
-        }
-
-        // 생성된 마스터 포트폴리오를 데이터베이스에 저장합니다.
-        const createdPortfolio = qr.manager.create(MasterPortfolioAI, {
-            user: { id: userId },
-            project: { id: projectId },
-            detailInfo: generatedPortfolio.detailInfo,
-            assignedTask: generatedPortfolio.assignedTask,
-            keyAchievement: generatedPortfolio.keyAchievement,
-            insight: generatedPortfolio.insight,
-        });
-
-        // TODO: 직접작성 기능을 도입하는 시점에는 해당 코드 삭제
-        // 생성된 결과를 마스터 포트폴리오 엔티티에도 저장합니다.
-        qr.manager.update(
-            MasterPortfolio,
-            { id: portfolioId },
-            {
-                detailInfo: generatedPortfolio.detailInfo,
-                assignedTask: generatedPortfolio.assignedTask,
-                keyAchievement: generatedPortfolio.keyAchievement,
-                insight: generatedPortfolio.insight,
-            }
-        );
-
-        try {
-            await qr.manager.save(MasterPortfolioAI, createdPortfolio);
-        } catch (e) {
-            console.error(`마스터 포트폴리오 AI 생성 중 오류 발생: ${e.message}`);
-            throw new InternalServerErrorException(
-                `Failed to save master portfolio AI: ${e.message}`
-            );
+            throw error;
         }
 
         // 생성된 마스터 포트폴리오 AI 결과를 반환합니다.
@@ -533,7 +512,6 @@ export class MasterPortfoliosService {
         portfolioId: number,
         updateDataDto: MasterPortfolioRequestDto
     ) {
-        console.log(updateDataDto);
         await qr.manager.update(
             MasterPortfolio,
             {
@@ -553,7 +531,7 @@ export class MasterPortfoliosService {
         return MasterPortfolioResponseDto.from(masterPortfolio);
     }
 
-    //사용자 별 마스터 포트폴리오 조회
+    // 사용자 별 마스터 포트폴리오 조회
     async getMasterPortfoliosByUser(userId: number, cursorDate: Date, pageSize: number) {
         const portfolios = await this.masterPortfolioRepository
             .createQueryBuilder('mp')
@@ -579,7 +557,7 @@ export class MasterPortfoliosService {
         return PaginatedResponseDto.of(result, nextCursor, hasNextPage);
     }
 
-    //마스터포트폴리오 소유자 체크
+    // 마스터포트폴리오 소유자 체크
     async checkMasterPortfolioOwner(userId: number, portfolioId: number): Promise<Boolean> {
         const masterPortfolio = await this.masterPortfolioRepository.findOne({
             where: { id: portfolioId },
@@ -615,7 +593,8 @@ export class MasterPortfoliosService {
         return plans.map((plan) => SelectablePlanResponseDto.fromEntity(plan));
     }
 
-    async getStatus(userId: number, portfolioId: number) {
+    // 진행 상태 조회
+    async getStatus(portfolioId: number) {
         const status = await this.masterPortfolioRepository.findOne({
             where: { id: portfolioId },
             select: ['status'],

--- a/src/modules/master-portfolios/services/master-portfolios.service.ts
+++ b/src/modules/master-portfolios/services/master-portfolios.service.ts
@@ -35,31 +35,7 @@ import { User } from '../../users/entities/users.entity';
 import { UserProject } from '../../projects/entities/userProjects.entity';
 import { SelectablePlanResponseDto } from '../dtos/selectable-plan.dto';
 import { MasterPortfolioStatus } from 'src/common/enums/master-portfolio-status.enum';
-
-function getPeriod(createdAt: Date, completedAt: Date): string {
-    let years = completedAt.getFullYear() - createdAt.getFullYear();
-    let months = completedAt.getMonth() - createdAt.getMonth();
-    let days = completedAt.getDate() - createdAt.getDate();
-
-    // 월 차이가 음수인 경우 보정
-    if (days < 0) {
-        months -= 1;
-        const prevMonth = new Date(completedAt.getFullYear(), completedAt.getMonth(), 0);
-        days += prevMonth.getDate();
-    }
-    // 연 차이가 음수인 경우 보정
-    if (months < 0) {
-        years -= 1;
-        months += 12;
-    }
-
-    // 0인 단위는 표시하지 않음
-    const period: string[] = [];
-    if (years > 0) period.push(`${years}년`);
-    if (months > 0) period.push(`${months}개월`);
-    if (days > 0) period.push(`${days}일`);
-    return period.join(' ');
-}
+import { getPeriod } from 'src/common/utils/get-period';
 
 type MasterPortfolioContentCheckResult = {
     [K in keyof MasterPortfolioOutput]?: boolean;
@@ -128,10 +104,14 @@ export class MasterPortfoliosService {
         }
         const masterPortfolioId = masterPortfolio.id;
         const projectId = masterPortfolio.project.id;
-        const detailInfo = masterPortfolio.detailInfo;
-        const assignedTask = masterPortfolio.assignedTask;
-        const keyAchievement = masterPortfolio.keyAchievement;
-        const insight = masterPortfolio.insight;
+
+        // 이미 생성된 질문이 있는지 확인합니다.
+        const existingQuestions = await qr.manager.findOne(Questions, {
+            where: { masterPortfolio: { id: masterPortfolioId } },
+        });
+        if (existingQuestions) {
+            throw new AIGenerationAlreadyExists();
+        }
 
         // recordId 정보 저장하기 (선택된 회의록)
         for (const recordId of recordIdList) {
@@ -143,7 +123,7 @@ export class MasterPortfoliosService {
         // 1. 선택된 회의록 내용
         const records = await qr.manager.find(Plan, {
             where: { id: In(recordIdList) },
-            select: ['meetingRecords'],
+            select: ['name', 'meetingRecords'],
         });
         // 2. 담당자로 지정된 모든 업무명
         const tasks = await qr.manager.find(Task, {
@@ -195,8 +175,8 @@ export class MasterPortfoliosService {
         const inputData: string = JSON.stringify({
             userName: userName?.name,
             role: role?.role,
-            projectName,
-            projectPeriod,
+            projectName: projectName,
+            projectPeriod: projectPeriod,
             createdAt,
             completedAt,
             category,
@@ -204,21 +184,7 @@ export class MasterPortfoliosService {
             records,
             tasks,
             personalRecalls,
-            masterPortfolio: {
-                detailInfo,
-                assignedTask,
-                keyAchievement,
-                insight,
-            },
         });
-
-        // 이미 생성된 질문이 있는지 확인합니다.
-        const existingQuestions = await qr.manager.findOne(Questions, {
-            where: { masterPortfolio: { id: masterPortfolioId } },
-        });
-        if (existingQuestions) {
-            throw new AIGenerationAlreadyExists();
-        }
 
         // LLM을 호출하여 질문을 생성합니다.
         const questions: Array<Question> = await this.llmService.generateQuestions(inputData);
@@ -281,7 +247,7 @@ export class MasterPortfoliosService {
             if (!questionExists) {
                 // questionId+portfolioId가 존재하지 않을 때
                 throw new BadRequestException(
-                    `Question with ID ${questionId} does not exist for portfolio ${portfolioId}`
+                    `Question ID ${questionId} does not exist for portfolio ${portfolioId}`
                 );
             }
 
@@ -346,6 +312,7 @@ export class MasterPortfoliosService {
 
         // 프로젝트 ID를 가져옵니다.
         const projectId = masterPortfolio.project.id;
+        const masterPortfolioId = masterPortfolio.id;
 
         // 이미 생성된 마스터 포트폴리오 AI가 있는지 확인합니다.
         const existingPortfolioAI = await this.masterPortfolioAIRepository.findOne({
@@ -355,8 +322,78 @@ export class MasterPortfoliosService {
             throw new AIGenerationAlreadyExists();
         }
 
-        // 임시로 더미 데이터 사용
+        // 입력할 데이터 가져오기
+        const questionData = await this.getQuestions(portfolioId);
         let projectData: any;
+
+        const plans = await qr.manager.find(Plan, {
+            where: { masterPortfolioId: portfolioId, project: { id: projectId } },
+            select: ['name', 'meetingRecords'],
+        });
+        // 1. 선택된 회의록 내용
+        const records = plans.map((plan) => ({
+            name: plan.name,
+            meetingRecords: plan.meetingRecords,
+        }));
+        // 2. 담당자로 지정된 모든 업무명
+        const tasks = await qr.manager.find(Task, {
+            where: { managers: { user: { id: userId } }, step: { project: { id: projectId } } },
+            select: ['name'],
+        });
+        // 3. 개인회고 내용
+        const personalRecalls = await qr.manager.findOne(PersonalRecall, {
+            where: { user: { id: userId }, project: { id: projectId } },
+            select: ['id', 'collaborationProfile', 'memorableExperience', 'strengthsAndGrowth'],
+        });
+        // 4. 프로젝트명, 진행기간
+        const projectInfo = await qr.manager.findOne(Project, {
+            where: { id: projectId },
+            select: ['createdAt', 'completedAt', 'name'],
+        });
+        if (!projectInfo) {
+            throw new ProjectNotFoundException(`Project with ID ${projectId} not found`);
+        }
+        const projectName: string = projectInfo.name; // 프로젝트명
+        const createdAt: Date = projectInfo.createdAt; // 2025-07-26T06:05:35.998Z, Date 객체
+        const completedAt: Date = projectInfo.completedAt || new Date(); // 완료일이 없으면 현재 시간으로 설정
+        const projectPeriod: string = getPeriod(createdAt, completedAt);
+
+        // 5. 분류 태그, 기여도
+        const masterPortfolioData = await qr.manager.findOne(MasterPortfolio, {
+            where: { id: masterPortfolioId },
+            select: ['category', 'contributionRate'],
+        });
+        if (!masterPortfolioData) {
+            throw new MasterPortfolioNotFoundException(
+                `Master portfolio with ID ${masterPortfolioId} not found`
+            );
+        }
+        const category: string = masterPortfolioData.category;
+        const contributionRate: number = masterPortfolioData.contributionRate;
+
+        // 6. 이름과 역할(role)
+        const userName = await qr.manager.findOne(User, {
+            where: { id: userId },
+            select: ['name'],
+        });
+        const role = await qr.manager.findOne(UserProject, {
+            where: { user: { id: userId }, project: { id: projectId } },
+            select: ['id', 'role'],
+        });
+
+        projectData = JSON.stringify({
+            userName: userName?.name,
+            role: role?.role,
+            projectName: projectName,
+            projectPeriod: projectPeriod,
+            createdAt,
+            completedAt,
+            category,
+            contributionRate,
+            records,
+            tasks,
+            personalRecalls,
+        });
 
         // 진행 상태를 `GENERATING`으로 업데이트합니다.
         await this.masterPortfolioRepository.update(
@@ -365,7 +402,7 @@ export class MasterPortfoliosService {
         );
 
         const generatedPortfolio: MasterPortfolioOutput =
-            await this.llmService.generateMasterPortfolio(projectData);
+            await this.llmService.generateMasterPortfolio(questionData, projectData);
         if (!generatedPortfolio) {
             // 실패 시, 상태를 이전으로 돌립니다.
             await this.masterPortfolioRepository.update(
@@ -378,6 +415,7 @@ export class MasterPortfoliosService {
             );
         }
 
+        console.log('생성된 마스터 포트폴리오:', generatedPortfolio);
         // 생성된 JSON 값 구조 검사
         const checkResult = checkMasterPortfolioContentStructure(generatedPortfolio);
         const isValid = Object.values(checkResult).every((value) => value === true);

--- a/src/modules/master-portfolios/types/content-check.type.ts
+++ b/src/modules/master-portfolios/types/content-check.type.ts
@@ -1,0 +1,5 @@
+import { MasterPortfolioOutput } from 'src/common/types/master-portfolio.type';
+
+export type MasterPortfolioContentCheckResult = {
+    [K in keyof MasterPortfolioOutput]?: boolean;
+};

--- a/src/modules/master-portfolios/types/project-data.interface.ts
+++ b/src/modules/master-portfolios/types/project-data.interface.ts
@@ -1,0 +1,14 @@
+import { portfolioType } from 'src/common/enums/portfolio-type.enum';
+import { PersonalRecall } from 'src/modules/personal-recalls/entities/personal-recalls.entity';
+
+export interface ProjectData {
+    userName: string;
+    role: string;
+    projectName: string;
+    projectPeriod: string;
+    category: portfolioType;
+    contributionRate: number;
+    records: Array<{ name: string; meetingRecords: string }>;
+    tasks: Array<{ name: string }>;
+    personalRecall: PersonalRecall | null;
+}


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #258 

## ✅ 작업 내용

- getPeriod 함수 util로 분리
- 마스터 포트폴리오 최종 생성 작업에 실제 데이터 활용
- 질문 생성에서 마스터 포트폴리오 내용 삭제
- MasterPortfolioContentCheckResult 별도 파일로 분리
- 불필요한 코드 및 주석 정리
- 프롬프트 파일 로딩 에러 메시지 수정 및 langchain 프롬프트 로딩 에러 처리 추가

## 📸 스크린샷

## 📎 기타 참고사항

- 프롬프트 관련 코드가 중복됨. 별도의 함수로 분리할 생각
- master-portfolio.service.ts 파일이 너무 길어서, 질문 관련 코드를 분리할까 고민 중
