### PR TITLE
[Refactor] 업무 상세 조회 responseDto수정

### DIFF
--- a/src/modules/tasks/dtos/get-task.dto.ts
+++ b/src/modules/tasks/dtos/get-task.dto.ts
@@ -61,6 +61,7 @@ export class GetTaskResponseDto {
             userName: m.user.name,
         }));
         dto.files = task.taskFiles.map((f) => ({
+            id: f.id,
             fileUrl: f.fileUrl,
         }));
         dto.stepId = task.step.id;

--- a/src/modules/tasks/task-files/dtos/create-task-files.dto.ts
+++ b/src/modules/tasks/task-files/dtos/create-task-files.dto.ts
@@ -2,6 +2,12 @@ import { ApiProperty } from '@nestjs/swagger';
 import { TaskFile } from '../task-files.entity';
 export class TaskFileResponseDto {
     @ApiProperty({
+        example: 1,
+        description: '파일 ID',
+    })
+    id: number;
+
+    @ApiProperty({
         example: 'https://s3.amazonaws.com/bucket/file.jpg',
         description: '파일 URL',
     })


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #280

## ✅ 작업 내용

- 업무 상세 조회 시 response에 taskFileId추가
- 이를 위해 TaskFileResponseDto 에 id추가

## 📸 스크린샷
<img width="920" height="536" alt="image" src="https://github.com/user-attachments/assets/0f2df196-7f96-43a7-8a30-11a864b98d8c" />


## 📎 기타 참고사항

