### PR TITLE
[Refactor] 업무관련 response DTO manager 수정

### DIFF
--- a/src/modules/tasks/dtos/create-manager-dto.ts
+++ b/src/modules/tasks/dtos/create-manager-dto.ts
@@ -1,9 +1,0 @@
-import { ApiProperty } from '@nestjs/swagger';
-
-export class ManagerResponseDto {
-    @ApiProperty({ example: 1, description: '담당자 userId' })
-    userId: number;
-
-    @ApiProperty({ example: '홍길동', description: '담당자 이름' })
-    userName: string;
-}

--- a/src/modules/tasks/dtos/get-task.dto.ts
+++ b/src/modules/tasks/dtos/get-task.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Status } from '../../../common/enums/status.enum';
-import { ManagerResponseDto } from './create-manager-dto';
+import { UserProfile } from 'src/common/dtos/user-profile.dto';
 import { TaskFileResponseDto } from '../task-files/dtos/create-task-files.dto';
 import { Task } from '../entities/tasks.entity';
 import { Manager } from '../entities/managers.entity';
@@ -33,10 +33,10 @@ export class GetTaskResponseDto {
     memo: string | null;
 
     @ApiProperty({
-        type: [ManagerResponseDto],
+        type: [UserProfile],
         description: '담당자 목록',
     })
-    managers: ManagerResponseDto[];
+    managers: UserProfile[];
 
     @ApiProperty({
         type: [TaskFileResponseDto],
@@ -56,10 +56,7 @@ export class GetTaskResponseDto {
         dto.deadline = task.deadline;
         dto.status = task.status;
         dto.memo = task.memo;
-        dto.managers = managers.map((m) => ({
-            userId: m.user.id,
-            userName: m.user.name,
-        }));
+        dto.managers = managers.map((m) => UserProfile.from(m.user));
         dto.files = task.taskFiles.map((f) => ({
             id: f.id,
             fileUrl: f.fileUrl,

--- a/src/modules/tasks/dtos/task-dashboard-status-view-dto.ts
+++ b/src/modules/tasks/dtos/task-dashboard-status-view-dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Status } from '../../../common/enums/status.enum';
-import { ManagerResponseDto } from './create-manager-dto';
 import { Task } from '../entities/tasks.entity';
+import { UserProfile } from 'src/common/dtos/user-profile.dto';
 
 export class TaskInStatusDto {
     @ApiProperty({
@@ -29,10 +29,10 @@ export class TaskInStatusDto {
     stepName: string;
 
     @ApiProperty({
-        type: [ManagerResponseDto],
+        type: [UserProfile],
         description: '담당자 목록',
     })
-    managers: ManagerResponseDto[];
+    managers: UserProfile[];
 
     @ApiProperty({
         example: '2025-08-31T15:00:00.000Z',
@@ -48,10 +48,7 @@ export class TaskInStatusDto {
         dto.stepId = task.step.id;
         dto.stepName = task.step.name;
         dto.deadline = task.deadline;
-        dto.managers = (task.managers ?? []).map((m) => ({
-            userId: m.user.id,
-            userName: m.user.name,
-        }));
+        dto.managers = (task.managers ?? []).map((m) => UserProfile.from(m.user));
         return dto;
     }
 }

--- a/src/modules/tasks/dtos/task-dashboard-step-view-dto.ts
+++ b/src/modules/tasks/dtos/task-dashboard-step-view-dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Status } from '../../../common/enums/status.enum';
-import { ManagerResponseDto } from './create-manager-dto';
 import { Task } from '../entities/tasks.entity';
+import { UserProfile } from 'src/common/dtos/user-profile.dto';
 
 export class TaskInStepDto {
     @ApiProperty({
@@ -24,10 +24,10 @@ export class TaskInStepDto {
     status: Status;
 
     @ApiProperty({
-        type: [ManagerResponseDto],
+        type: [UserProfile],
         description: '담당자 목록',
     })
-    managers: ManagerResponseDto[];
+    managers: UserProfile[];
 
     @ApiProperty({
         example: '2025-08-31T15:00:00.000Z',
@@ -42,10 +42,7 @@ export class TaskInStepDto {
         dto.taskName = task.name;
         dto.status = task.status;
         dto.deadline = task.deadline;
-        dto.managers = (task.managers ?? []).map((m) => ({
-            userId: m.user.id,
-            userName: m.user.name,
-        }));
+        dto.managers = (task.managers ?? []).map((m) => UserProfile.from(m.user));
 
         return dto;
     }

--- a/src/modules/tasks/dtos/update-task.dto.ts
+++ b/src/modules/tasks/dtos/update-task.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Status } from '../../../common/enums/status.enum';
 import { IsOptional, IsNotEmpty, IsEnum, IsArray, IsNumber } from 'class-validator';
-import { ManagerResponseDto } from './create-manager-dto';
+import { UserProfile } from 'src/common/dtos/user-profile.dto';
 import { Type } from 'class-transformer';
 import { Task } from '../entities/tasks.entity';
 import { Manager } from '../entities/managers.entity';
@@ -83,10 +83,10 @@ export class UpdateTaskResponseDto {
     memo: string | null;
 
     @ApiProperty({
-        type: [ManagerResponseDto],
+        type: [UserProfile],
         description: '담당자 목록',
     })
-    managers: ManagerResponseDto[];
+    managers: UserProfile[];
 
     @IsNotEmpty()
     @ApiProperty({
@@ -101,10 +101,7 @@ export class UpdateTaskResponseDto {
         dto.deadline = task.deadline;
         dto.status = task.status;
         dto.memo = task.memo;
-        dto.managers = managers.map((m) => ({
-            userId: m.user.id,
-            userName: m.user.name,
-        }));
+        dto.managers = managers.map((m) => UserProfile.from(m.user));
         dto.stepId = task.step.id;
         return dto;
     }

--- a/src/modules/tasks/repositories/manager.repository.ts
+++ b/src/modules/tasks/repositories/manager.repository.ts
@@ -28,7 +28,7 @@ export class ManagerRepository {
             relations: ['user'],
             select: {
                 id: true,
-                user: { id: true, name: true },
+                user: { id: true, name: true, imageUrl:true },
             },
         });
     }

--- a/src/modules/tasks/repositories/task.repository.ts
+++ b/src/modules/tasks/repositories/task.repository.ts
@@ -90,13 +90,13 @@ export class TaskRepository {
         return this.repo
             .createQueryBuilder('task')
             .leftJoinAndSelect('task.step', 'step')
-            .leftJoin('task.managers', 'manager')
-            .leftJoin('manager.user', 'user')
-            .addSelect(['user.id', 'user.name'])
+            .leftJoinAndSelect('task.managers', 'manager')
+            .leftJoinAndSelect('manager.user', 'user')
             .where('step.projectId = :projectId', { projectId })
             .andWhere('task.status = :status', { status })
             .orderBy('task.deadline', 'ASC')
             .addOrderBy('task.createdAt', 'ASC')
+            .distinct(true)
             .limit(limit)
             .getMany();
     }
@@ -110,13 +110,13 @@ export class TaskRepository {
         return this.repo
             .createQueryBuilder('task')
             .leftJoinAndSelect('task.step', 'step')
-            .leftJoin('task.managers', 'manager')
-            .leftJoin('manager.user', 'user')
-            .addSelect(['user.id', 'user.name'])
+            .leftJoinAndSelect('task.managers', 'manager')
+            .leftJoinAndSelect('manager.user', 'user')
             .where('step.projectId = :projectId', { projectId })
-            .andWhere('task.stepId = :stepId', { stepId })
+            .andWhere('step.id = :stepId', { stepId })
             .orderBy('task.deadline', 'ASC')
             .addOrderBy('task.createdAt', 'ASC')
+            .distinct(true)
             .limit(limit)
             .getMany();
     }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #283

## ✅ 작업 내용

- 업무 대시보드 response DTO에서 manager수정
- 업무 상세조회 response DTO에서 manager ImgageURL추가
- 업무 수정 response DTO에서 manager ImgageURL추가

## 📸 스크린샷

업무 상세조회
<img width="1269" height="590" alt="업무상세조회DTO" src="https://github.com/user-attachments/assets/6fa7ed24-434e-48c3-be66-d5f57961f8d4" />

업무 수정
<img width="1283" height="485" alt="업무 수정 DTO" src="https://github.com/user-attachments/assets/8aa24a41-3adc-459d-9aec-439ae6a87bfa" />

업무 대시보드
<img width="1244" height="527" alt="image" src="https://github.com/user-attachments/assets/5c3a9692-41cb-4361-a305-d8fc728dbe9d" />


## 📎 기타 참고사항

- 
