### PR TITLE
[Feat] 유틸리티 함수 분리 및 추가, 최소 생성 시간 설정 추가

### DIFF
--- a/src/common/utils/check-masterportfolio-structure.util.ts
+++ b/src/common/utils/check-masterportfolio-structure.util.ts
@@ -1,0 +1,36 @@
+import { MasterPortfolioContentCheckResult } from 'src/modules/master-portfolios/types/content-check.type';
+import { MasterPortfolioOutput } from '../types/master-portfolio.type';
+
+export function checkMasterPortfolioContentStructure(
+    data: MasterPortfolioOutput
+): MasterPortfolioContentCheckResult {
+    const results: MasterPortfolioContentCheckResult = {};
+
+    // 프로젝트명 검사 : 1~20자
+    // results.projectName =
+    //     typeof data.projectName === 'string' &&
+    //     data.projectName.length > 0 &&
+    //     data.projectName.length <= 20;
+
+    // 상세정보 검사 : 최소 4개 이상의 리스트 (-로 시작)
+    results.detailInfo =
+        typeof data.detailInfo === 'string' && (data.detailInfo.match(/^- /gm)?.length ?? 0) >= 4;
+
+    // 담당업무 검사 : [섹션명]으로 시작하는 구간 1개 이상, 각 섹션에 -로 시작하는 리스트 1개 이상
+    // TODO: 구조(순서)까지는 검사하지 못하는 문제가 있음. 개선해볼 것
+    results.assignedTask =
+        typeof data.assignedTask === 'string' &&
+        /\[.+\]/.test(data.assignedTask) &&
+        (data.assignedTask.match(/^- /gm)?.length ?? 0) >= 1;
+
+    // 주요성과 검사 : -로 시작하는 리스트 2개 이상
+    results.keyAchievement =
+        typeof data.keyAchievement === 'string' &&
+        (data.keyAchievement.match(/^- /gm)?.length ?? 0) >= 2;
+
+    // 배운점 검사 : -로 시작하는 문장 2개 이상
+    results.insight =
+        typeof data.insight === 'string' && (data.insight.match(/^- /gm)?.length ?? 0) >= 2;
+
+    return results;
+}

--- a/src/common/utils/response-delay.util.ts
+++ b/src/common/utils/response-delay.util.ts
@@ -1,0 +1,28 @@
+async function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class ResponseDelayManager {
+    static async ensureMinimumDuration<T>(
+        asyncOperation: Promise<T>,
+        minDurationMs: number = 35000
+    ): Promise<T> {
+        const startTime = Date.now();
+
+        // LLM 작업 실행
+        const result = await asyncOperation;
+
+        // 경과 시간 계산
+        const elapsed = Date.now() - startTime;
+        const remaining = minDurationMs - elapsed;
+
+        // 35초보다 빠르게 끝났으면 남은 시간만큼 대기
+        if (remaining > 0) {
+            await delay(remaining);
+        }
+
+        console.log(`실제 걸린 시간: ${elapsed}ms, 대기 시간: ${remaining}ms`);
+
+        return result;
+    }
+}

--- a/src/infra/llm/llm.service.ts
+++ b/src/infra/llm/llm.service.ts
@@ -12,6 +12,8 @@ import { PortfolioCorrection } from 'src/modules/portfolio-corrections/entities/
 import { Questions, questionSchema } from './schemas/questions.schema';
 import { MasterPortfolio, masterPortfolioSchema } from './schemas/master-portfolio.schema';
 import { ProjectData } from 'src/modules/master-portfolios/types/project-data.interface';
+import { ResponseDelayManager } from 'src/common/utils/response-delay.util';
+import { checkMasterPortfolioContentStructure } from 'src/common/utils/check-masterportfolio-structure.util';
 
 function processLLMError(error: any) {
     // JSON 파싱 실패
@@ -189,35 +191,50 @@ export class LLMService {
             }
         );
 
-        try {
-            const masterPortfolioResult = await masterPortfolioPrompt.pipe(structuredLLM).invoke({
-                questionData: questionData,
-                projectData: projectData,
-            });
+        const operation = async () => {
+            try {
+                const masterPortfolioResult = await masterPortfolioPrompt
+                    .pipe(structuredLLM)
+                    .invoke({
+                        questionData: questionData,
+                        projectData: projectData,
+                    });
 
-            // 출력 실패
-            if (
-                !masterPortfolioResult ||
-                !masterPortfolioResult.detailInfo ||
-                !masterPortfolioResult.assignedTask ||
-                !masterPortfolioResult.keyAchievement ||
-                !masterPortfolioResult.insight
-            ) {
+                console.log(masterPortfolioResult);
+                // 출력 실패
+                if (
+                    !masterPortfolioResult ||
+                    !masterPortfolioResult.detailInfo ||
+                    !masterPortfolioResult.assignedTask ||
+                    !masterPortfolioResult.keyAchievement ||
+                    !masterPortfolioResult.insight
+                ) {
+                    throw new InternalServerErrorException(
+                        'LLM에서 빈 결과를 포함하여 생성했습니다.'
+                    );
+                }
+
+                // 생성된 JSON 값 구조 검사
+                const checkResult = checkMasterPortfolioContentStructure(masterPortfolioResult);
+                const isValid = Object.values(checkResult).every((value) => value === true);
+                if (!isValid) {
+                    throw new InternalServerErrorException(
+                        '생성된 마스터 포트폴리오의 구조가 유효하지 않습니다.'
+                    );
+                }
+
+                return masterPortfolioResult;
+            } catch (error) {
+                // 각종 에러 체크
+                processLLMError(error);
+
+                // 이외의 모든 에러
                 throw new InternalServerErrorException(
-                    'LLM에서 유효한 마스터 포트폴리오 구조를 생성하지 못했습니다.'
+                    `마스터 포트폴리오 생성 중 알 수 없는 오류가 발생했습니다. [${error?.constructor?.name}] ${error}`
                 );
             }
-
-            return masterPortfolioResult;
-        } catch (error) {
-            // 각종 에러 체크
-            processLLMError(error);
-
-            // 이외의 모든 에러
-            throw new InternalServerErrorException(
-                `마스터 포트폴리오 생성 중 알 수 없는 오류가 발생했습니다. [${error?.constructor?.name}] ${error}`
-            );
-        }
+        };
+        return ResponseDelayManager.ensureMinimumDuration(operation());
     }
 
     // AI 첨삭 생성
@@ -251,6 +268,7 @@ export class LLMService {
                 name: 'correction',
             }
         );
+
         const correctionResult = await correctionPrompt.pipe(structuredLLM).invoke({
             companyName: portfolioCorrectionData.submissionTarget,
             jobTitle: portfolioCorrectionData.jobTitle,

--- a/src/infra/llm/rag.service.ts
+++ b/src/infra/llm/rag.service.ts
@@ -1,7 +1,7 @@
 import { TavilySearchAPIRetriever } from '@langchain/community/retrievers/tavily_search_api';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
 import { ChatOpenAI } from '@langchain/openai';
-import { Injectable } from '@nestjs/common';
+import { Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { RAGDataType } from 'src/common/enums/rag-data-type.enum';
 import { PromptLoadingException } from 'src/common/exceptions/custom.errors';
 import { PromptLoader } from 'src/common/utils/prompt.loader';
@@ -9,6 +9,7 @@ import { RAGData } from 'src/modules/portfolio-corrections/entities/rag-data.ent
 import { QueryRunner } from 'typeorm';
 import { SearchQuery, searchQuerySchema } from './schemas/portfolio-correction.schema';
 import { StringOutputParser } from '@langchain/core/output_parsers';
+import { PortfolioCorrection } from 'src/modules/portfolio-corrections/entities/portfolio-correction.entity';
 
 @Injectable()
 export class RagService {
@@ -50,6 +51,16 @@ export class RagService {
 
     // TODO: 추후 SSE 방식 도입 필요
     async startRAG(qr: QueryRunner, correctionId: number) {
+        // 이미 진행되었는지 여부 확인
+        const status = await qr.manager.findOne(PortfolioCorrection, {
+            where: { id: correctionId },
+            select: ['status'],
+        });
+        // 이미 진행된 상태인 경우, RAG 프로세스 중단
+        if (status && (status.status === 'DONE' || status.status === 'COMPANY_INSIGHT')) {
+            throw new InternalServerErrorException('이미 RAG가 진행되었습니다.');
+        }
+
         // step1. 검색어 추출
         const keywords = await this.extractSearchQuery(qr, correctionId);
 
@@ -74,13 +85,20 @@ export class RagService {
             name: 'searchQuery',
         });
 
-        // TODO: 개수 제한 작동 안함. 프롬프트 개선하기
+        const inputData = await qr.manager.findOne(PortfolioCorrection, {
+            where: { id: correctionId },
+        });
+        if (!inputData) {
+            throw new NotFoundException('포트폴리오 첨삭 데이터를 찾을 수 없습니다.');
+        }
+
+        // TODO: 키워드 개수 제한이 프롬프트에서 적용되지 않고 있음.
+        // 최종적으로 k개의 키워드 추출
         const extractedQuery = await queryExtractionPrompt.pipe(queryExtractor).invoke({
-            companyName: '레진코믹스',
-            jobTitle: '글로벌 MD',
-            jobDescription:
-                '담당업무\n- 국내외 MD 유통 업체 관리\n- MD 수출 과정 핸들링\n-> 오더 주문, 수금, 발주, 출고 등 관리\n-> 서류 통관 인허가, 면장 등\n- 공급 매출 정산 업무 (ERP 시스템 판매 정보 및 결산)\n\n자격요건\n- 영어 비즈니스 커뮤니케이션이 가능하신 분\n- K-POP, 웹툰IP의 이해도를 가지고 계신 분\n- 문서 프로그램 엑셀 활용 능력이 높으신 분\n- 대내/외 원활한 소통 능력을 갖추신 분\n\n우대요건\n- 주도적인 목표 수립과 실행력을 보유하신 분\n- 여성향 장르 웹툰에 대한 이해도가 높으신 분\n- 대중적인 트렌드에 민감하고 시장 트렌드 분석이 가능하신 분\n- 팀워크를 중시하며 긍정적인 커뮤니케이션 마인드를 보유하신 분\n- 팬덤 비즈니스에 대한 높은 이해도를 보유하신 분\n- ERP, 상급 수준의 MS Office 활용, 도구 툴 활용이 가능하신 분 (Excel, Power Point 등)\n- 해외 출장 업무에 거부감이 없으신 분',
-            k: 2,
+            companyName: inputData.submissionTarget,
+            jobTitle: inputData.jobTitle,
+            jobDescription: inputData.jd,
+            k: parseInt(process.env.REQUIRED_KEYWORD_COUNT || '2', 10),
         });
 
         const queryList = extractedQuery.query.split(',').map((q) => q.trim());
@@ -112,18 +130,20 @@ export class RagService {
 
         // TODO: metadata의 score 활용해서 점수 기반 정렬 등의 작업
         const searchResults: string[] = [];
-        combinedResults.forEach(async (result) => {
-            const title = result.metadata.title;
-            const link = result.metadata.source;
-            await qr.manager.save(RAGData, {
-                portfolioCorrection: { id: correctionId },
-                type: RAGDataType.LINK,
-                link,
-                title,
-            });
+        await Promise.all(
+            combinedResults.map(async (result) => {
+                const title = result.metadata.title;
+                const link = result.metadata.source;
+                await qr.manager.save(RAGData, {
+                    portfolioCorrection: { id: correctionId },
+                    type: RAGDataType.LINK,
+                    link,
+                    title,
+                });
 
-            searchResults.push(result.pageContent);
-        });
+                searchResults.push(result.pageContent);
+            })
+        );
         return searchResults;
     }
 

--- a/src/modules/master-portfolios/services/master-portfolios.service.ts
+++ b/src/modules/master-portfolios/services/master-portfolios.service.ts
@@ -35,42 +35,8 @@ import { UserProject } from '../../projects/user-projects/entities/user-projects
 import { SelectablePlanResponseDto } from '../dtos/selectable-plan.dto';
 import { MasterPortfolioStatus } from 'src/common/enums/master-portfolio-status.enum';
 import { getPeriod } from 'src/common/utils/get-period';
-import { MasterPortfolioContentCheckResult } from '../types/content-check.type';
 import { ProjectData } from '../types/project-data.interface';
-
-function checkMasterPortfolioContentStructure(
-    data: MasterPortfolioOutput
-): MasterPortfolioContentCheckResult {
-    const results: MasterPortfolioContentCheckResult = {};
-
-    // 프로젝트명 검사 : 1~20자
-    // results.projectName =
-    //     typeof data.projectName === 'string' &&
-    //     data.projectName.length > 0 &&
-    //     data.projectName.length <= 20;
-
-    // 상세정보 검사 : 최소 4개 이상의 리스트 (-로 시작)
-    results.detailInfo =
-        typeof data.detailInfo === 'string' && (data.detailInfo.match(/^- /gm)?.length ?? 0) >= 4;
-
-    // 담당업무 검사 : [섹션명]으로 시작하는 구간 1개 이상, 각 섹션에 -로 시작하는 리스트 1개 이상
-    // TODO: 구조(순서)까지는 검사하지 못하는 문제가 있음. 개선해볼 것
-    results.assignedTask =
-        typeof data.assignedTask === 'string' &&
-        /\[.+\]/.test(data.assignedTask) &&
-        (data.assignedTask.match(/^- /gm)?.length ?? 0) >= 1;
-
-    // 주요성과 검사 : -로 시작하는 리스트 2개 이상
-    results.keyAchievement =
-        typeof data.keyAchievement === 'string' &&
-        (data.keyAchievement.match(/^- /gm)?.length ?? 0) >= 2;
-
-    // 배운점 검사 : -로 시작하는 문장 2개 이상
-    results.insight =
-        typeof data.insight === 'string' && (data.insight.match(/^- /gm)?.length ?? 0) >= 2;
-
-    return results;
-}
+import { checkMasterPortfolioContentStructure } from 'src/common/utils/check-masterportfolio-structure.util';
 
 async function getProjectData(
     qr: QueryRunner,
@@ -386,14 +352,6 @@ export class MasterPortfoliosService {
             }
 
             console.log('생성된 마스터 포트폴리오:', generatedPortfolio);
-            // 생성된 JSON 값 구조 검사
-            const checkResult = checkMasterPortfolioContentStructure(generatedPortfolio);
-            const isValid = Object.values(checkResult).every((value) => value === true);
-            if (!isValid) {
-                throw new InternalServerErrorException(
-                    '생성된 마스터 포트폴리오의 구조가 유효하지 않습니다.'
-                );
-            }
 
             // 생성된 마스터 포트폴리오를 데이터베이스에 저장합니다.
             const createdPortfolio = qr.manager.create(MasterPortfolioAI, {
@@ -407,7 +365,7 @@ export class MasterPortfoliosService {
 
             // TODO: 직접작성 기능을 도입하는 시점에는 해당 코드 삭제
             // 생성된 결과를 마스터 포트폴리오 엔티티에도 저장합니다.
-            qr.manager.update(
+            await qr.manager.update(
                 MasterPortfolio,
                 { id: portfolioId },
                 {

--- a/src/modules/portfolio-corrections/services/portfolio-corrections.service.ts
+++ b/src/modules/portfolio-corrections/services/portfolio-corrections.service.ts
@@ -24,6 +24,7 @@ import { PortfolioCorrectionResponseDto } from '../dtos/portfolio-correction-res
 import { RagResponseDto } from '../dtos/rag-response.dto';
 import { StatusResponseDto } from '../dtos/status-response.dto';
 import { CorrectionResultDto } from '../dtos/correction-result.dto';
+import { ResponseDelayManager } from 'src/common/utils/response-delay.util';
 
 async function checkCorrectionExists(qr: QueryRunner, correctionId: number) {
     // correctionId에 해당하는 포트폴리오 첨삭 엔티티가 있는지
@@ -131,76 +132,79 @@ export class PortfolioCorrectionsService {
             })
         );
 
-        try {
-            const correctionPromises = selectedProjects.map(async (projectId) => {
-                // 프로젝트에 해당하는 포트폴리오 데이터 조회
-                const portfolioData = await qr.manager.findOne(MasterPortfolioAI, {
-                    where: { project: { id: projectId }, user: { id: userId } },
-                });
-                const project = await qr.manager.findOne(Project, {
-                    where: { id: projectId },
-                    select: ['name'],
-                });
-                const projectName = project?.name;
+        const operation = async () => {
+            try {
+                const correctionPromises = selectedProjects.map(async (projectId) => {
+                    // 프로젝트에 해당하는 포트폴리오 데이터 조회
+                    const portfolioData = await qr.manager.findOne(MasterPortfolioAI, {
+                        where: { project: { id: projectId }, user: { id: userId } },
+                    });
+                    const project = await qr.manager.findOne(Project, {
+                        where: { id: projectId },
+                        select: ['name'],
+                    });
+                    const projectName = project?.name;
 
-                // TODO: 생성 중 실패 시에 롤백 처리 필요
+                    // TODO: 생성 중 실패 시에 롤백 처리 필요
+                    // 진행 상태 업데이트
+                    await this.correctionRepository.update(correctionId, {
+                        status: PortfolioCorrectionStatus.GENERATING,
+                    });
+
+                    // LLM을 통해 첨삭 생성
+                    const correctionResult = await this.llmService.generateCorrection(
+                        qr,
+                        correctionId,
+                        portfolioData
+                    );
+
+                    // zod 스키마로 검증
+                    let correction: Correction;
+                    try {
+                        correction = correctionSchema.parse(correctionResult);
+                    } catch (error) {
+                        console.error(`zod 스키마 검증 실패. 프로젝트 ${projectId}:`, error.errors);
+                        throw new Error(`zod 검증 실패. 프로젝트 ${projectId}`);
+                    }
+
+                    // DB에 저장
+                    await qr.manager.save(AICorrection, {
+                        projectId,
+                        portfolioCorrection: existCorrectionPortfolio,
+                        modelName:
+                            process.env.LLM_CORRECTION_MODEL ||
+                            'google/gemini-2.5-flash-lite-preview-06-17',
+                        llmTemperature: 0.3,
+                        correctionResult: correction,
+                    });
+
+                    const result = {
+                        projectId,
+                        projectName,
+                        correction,
+                    };
+                    // TODO: 수정 필요
+                    // return CorrectionResultDto.from(result);
+                    return result;
+                });
+
+                // 모든 첨삭 작업 대기
+                const correctionResults = await Promise.all(correctionPromises);
+                // 결과 합치기
+                const mergedCorrection = [...correctionResults];
+
                 // 진행 상태 업데이트
-                await this.correctionRepository.update(correctionId, {
-                    status: PortfolioCorrectionStatus.GENERATING,
+                await qr.manager.update(PortfolioCorrection, correctionId, {
+                    status: PortfolioCorrectionStatus.DONE,
                 });
 
-                // LLM을 통해 첨삭 생성
-                const correctionResult = await this.llmService.generateCorrection(
-                    qr,
-                    correctionId,
-                    portfolioData
-                );
-
-                // zod 스키마로 검증
-                let correction: Correction;
-                try {
-                    correction = correctionSchema.parse(correctionResult);
-                } catch (error) {
-                    console.error(`zod 스키마 검증 실패. 프로젝트 ${projectId}:`, error.errors);
-                    throw new Error(`zod 검증 실패. 프로젝트 ${projectId}`);
-                }
-
-                // DB에 저장
-                await qr.manager.save(AICorrection, {
-                    projectId,
-                    portfolioCorrection: existCorrectionPortfolio,
-                    modelName:
-                        process.env.LLM_CORRECTION_MODEL ||
-                        'google/gemini-2.5-flash-lite-preview-06-17',
-                    llmTemperature: 0.3,
-                    correctionResult: correction,
-                });
-
-                const result = {
-                    projectId,
-                    projectName,
-                    correction,
-                };
-                // TODO: 수정 필요
-                // return CorrectionResultDto.from(result);
-                return result;
-            });
-
-            // 모든 첨삭 작업 대기
-            const correctionResults = await Promise.all(correctionPromises);
-            // 결과 합치기
-            const mergedCorrection = [...correctionResults];
-
-            // 진행 상태 업데이트
-            await qr.manager.update(PortfolioCorrection, correctionId, {
-                status: PortfolioCorrectionStatus.DONE,
-            });
-
-            return mergedCorrection;
-        } catch (error) {
-            console.error('첨삭 과정 중 실패: ', error);
-            throw new Error('첨삭 과정 중 실패');
-        }
+                return mergedCorrection;
+            } catch (error) {
+                console.error('첨삭 과정 중 실패: ', error);
+                throw new Error('첨삭 과정 중 실패');
+            }
+        };
+        return ResponseDelayManager.ensureMinimumDuration(operation());
     }
 
     // TODO: correctionId로 해당하는 프로젝트 id들과 첫 결과만 가져오고, 다른 프로젝트들을 각각 projectId로 로드하는 API를 따로 만들까 생각 중


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #277 

## ✅ 작업 내용

- 최소 생성 시간을 설정할 수 있는 util 함수 추가
- 코드 내 임시 데이터 사용 및 하드코딩된 값 제거 후, 실제 DB 조회
- checkMasterPortfolioContentStructure 유틸리티 함수는 별도 파일로 분리
- 마스터 포트폴리오에서 await 누락된 부분 추가

## 📸 스크린샷

<img width="263" height="41" alt="image" src="https://github.com/user-attachments/assets/54408b05-e06c-4699-a0e9-dba7c142feab" />

## 📎 기타 참고사항

- 마스터 포트폴리오 생성 결과가 에러 처리된 이후에도, DB에 저장되는 경우가 있는 것 같아서 확인 필요
