### PR TITLE
[Refactor] 업무 파일 생성시 파일명 함께 저장, 업무 파일 업로드 개수 제한

### DIFF
--- a/src/common/exceptions/custom.errors.ts
+++ b/src/common/exceptions/custom.errors.ts
@@ -31,6 +31,17 @@ export class InvalidDateException extends CustomHttpException {
     }
 }
 
+export class TaskFileLimitExceededException extends CustomHttpException {
+    constructor(data?: any) {
+        super(
+            ErrorCode.TASK_FILE_LIMIT_EXCEEDED,
+            '업무에는 최대 3개의 파일만 업로드할 수 있습니다.',
+            HttpStatus.BAD_REQUEST,
+            data
+        );
+    }
+}
+
 //401
 export class UnAuthorizedException extends CustomHttpException {
     constructor(data?: any) {

--- a/src/common/exceptions/errorcode.enum.ts
+++ b/src/common/exceptions/errorcode.enum.ts
@@ -28,6 +28,8 @@ export enum ErrorCode {
     //업무
     TASK_NOT_FOUND = 'TASK4041',
     TASK_FILE_NOT_FOUND = 'TASKFILE4042',
+    //업무파일
+    TASK_FILE_LIMIT_EXCEEDED = 'TASK_FILE_LIMIT_EXCEEDED',
     //개인회고
     PERSONAL_RECALL_NOT_FOUND = 'PERSONALRECALL4041',
     //스텝

--- a/src/modules/tasks/dtos/get-task.dto.ts
+++ b/src/modules/tasks/dtos/get-task.dto.ts
@@ -60,6 +60,7 @@ export class GetTaskResponseDto {
         dto.files = task.taskFiles.map((f) => ({
             id: f.id,
             fileUrl: f.fileUrl,
+            name: f.name,
         }));
         dto.stepId = task.step.id;
         return dto;

--- a/src/modules/tasks/dtos/update-task-status.dto.ts
+++ b/src/modules/tasks/dtos/update-task-status.dto.ts
@@ -4,10 +4,11 @@ import { Task } from '../entities/tasks.entity';
 import { IsNotEmpty, IsEnum } from 'class-validator';
 
 export class UpdateTaskStatusRequestDto {
-    @ApiProperty({ 
-        enum: Status, 
+    @ApiProperty({
+        enum: Status,
         example: 'ONGOING',
-        description: '변경할 상태' })
+        description: '변경할 상태',
+    })
     @IsNotEmpty()
     status: Status;
 }

--- a/src/modules/tasks/repositories/manager.repository.ts
+++ b/src/modules/tasks/repositories/manager.repository.ts
@@ -28,7 +28,7 @@ export class ManagerRepository {
             relations: ['user'],
             select: {
                 id: true,
-                user: { id: true, name: true, imageUrl:true },
+                user: { id: true, name: true, imageUrl: true },
             },
         });
     }

--- a/src/modules/tasks/services/tasks.service.ts
+++ b/src/modules/tasks/services/tasks.service.ts
@@ -38,6 +38,7 @@ import {
     UpdateTaskStatusRequestDto,
 } from '../dtos/update-task-status.dto';
 import { ManagerRepository } from '../repositories/manager.repository';
+import { TaskFileLimitExceededException } from 'src/common/exceptions/custom.errors';
 
 @Injectable()
 export class TasksService {
@@ -305,7 +306,19 @@ export class TasksService {
         // 2. 프로젝트 참여자 여부 확인
         await this.projectsService.assertProjectMember(userId, task.step.project.id);
 
+        const currentCount = await queryRunner.manager.count(TaskFile, {
+            where: { task: { id: taskId } },
+        });
+
+        const MAX_FILES_PER_TASK =
+            Number(this.configService.get<string>('MAX_FILES_PER_TASK')) || 3;
+        if (currentCount >= MAX_FILES_PER_TASK) {
+            throw new TaskFileLimitExceededException();
+        }
         const fileUrl = await this.uploadService.uploadFile(file);
+
+        // 3. 파일명 인코딩 복원 (latin1 -> utf8)
+        const name = Buffer.from(file.originalname, 'latin1').toString('utf8');
 
         // 4. TaskFile 생성
         const taskFile = queryRunner.manager.create(TaskFile);
@@ -313,6 +326,7 @@ export class TasksService {
             fileUrl,
             task: { id: taskId },
             user: { id: userId },
+            name,
         });
 
         // 5. DB 저장

--- a/src/modules/tasks/task-files/dtos/create-task-files.dto.ts
+++ b/src/modules/tasks/task-files/dtos/create-task-files.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { TaskFile } from '../task-files.entity';
+
 export class TaskFileResponseDto {
     @ApiProperty({
         example: 1,
@@ -12,6 +13,12 @@ export class TaskFileResponseDto {
         description: '파일 URL',
     })
     fileUrl: string;
+
+    @ApiProperty({
+        example: 'UI 가이드.pdf',
+        description: '표시용 파일명',
+    })
+    name: string;
 }
 
 export class CreateTaskFileResponseDto {
@@ -21,10 +28,17 @@ export class CreateTaskFileResponseDto {
     @ApiProperty({ example: 'https://s3.amazonaws.com/...', description: '파일 URL' })
     fileUrl: string;
 
+    @ApiProperty({
+        example: 'UI 가이드.pdf',
+        description: '파일명',
+    })
+    name: string;
+
     static fromEntity(entity: TaskFile): CreateTaskFileResponseDto {
         const dto = new CreateTaskFileResponseDto();
         dto.id = entity.id;
         dto.fileUrl = entity.fileUrl;
+        dto.name = entity.name;
         return dto;
     }
 }

--- a/src/modules/tasks/task-files/task-files.controller.ts
+++ b/src/modules/tasks/task-files/task-files.controller.ts
@@ -4,9 +4,7 @@ import { User } from 'src/common/decorators/user.decorator';
 import { TaskFilesService } from './task-files.service';
 import { ErrorCode } from '../../../common/exceptions/errorcode.enum';
 import { HttpStatus } from '@nestjs/common';
-import {
-    ApiCommonErrorResponse,
-} from 'src/common/response/swagger-response.helper';
+import { ApiCommonErrorResponse } from 'src/common/response/swagger-response.helper';
 
 import { Transactional } from 'src/common/decorators/transaction.decorator';
 import { TransactionalRequest } from 'src/common/decorators/transaction.decorator';
@@ -32,9 +30,8 @@ export class TaskFilesController {
     @Delete('/:taskFileId')
     async deleteTaskFile(
         @Req() req: TransactionalRequest,
-        @User('id') userId: number,
         @Param('taskFileId') fileId: number
     ): Promise<CommonResponse> {
-        return this.taskFilesService.deleteTaskFile(req.queryRunner, userId, fileId);
+        return this.taskFilesService.deleteTaskFile(req.queryRunner, fileId);
     }
 }

--- a/src/modules/tasks/task-files/task-files.entity.ts
+++ b/src/modules/tasks/task-files/task-files.entity.ts
@@ -8,6 +8,9 @@ export class TaskFile extends BaseEntity {
     @Column({ length: 255 })
     fileUrl: string;
 
+    @Column({ length: 255 })
+    name: string;
+
     @ManyToOne(() => Task, (task) => task.taskFiles, { onDelete: 'CASCADE' })
     task: Task;
 

--- a/src/modules/tasks/task-files/task-files.service.ts
+++ b/src/modules/tasks/task-files/task-files.service.ts
@@ -14,11 +14,7 @@ export class TaskFilesService {
         private readonly taskFileRepository: TaskFileRepository
     ) {}
 
-    async deleteTaskFile(
-        queryRunner: QueryRunner,
-        userId: number,
-        fileId: number
-    ): Promise<CommonResponse> {
+    async deleteTaskFile(queryRunner: QueryRunner, fileId: number): Promise<CommonResponse> {
         const file = await this.taskFileRepository.findTaskFileByIdWithQueryRunner(
             queryRunner,
             fileId

--- a/src/modules/tasks/tasks.controller.ts
+++ b/src/modules/tasks/tasks.controller.ts
@@ -54,7 +54,10 @@ import { DateCursor } from 'src/common/dtos/date-cursor.dto';
 import { GetSearchTaskDto } from './dtos/get-search-task.dto';
 import { ErrorCode } from '../../common/exceptions/errorcode.enum';
 import { HttpStatus } from '@nestjs/common';
-import { UpdateTaskStatusResponseDto, UpdateTaskStatusRequestDto } from './dtos/update-task-status.dto';
+import {
+    UpdateTaskStatusResponseDto,
+    UpdateTaskStatusRequestDto,
+} from './dtos/update-task-status.dto';
 
 @ApiTags('Tasks')
 @Controller('/tasks')


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #291

## ✅ 작업 내용

- 업무 파일명 DB 수정 및 저장
- 업무 파일 업로드 개수 3개 제한

## 📸 스크린샷
업무 파일 생성시 파일명 저장
<img width="2144" height="1001" alt="스크린샷 2025-08-13 162228" src="https://github.com/user-attachments/assets/50ae414c-8537-4b26-9bf1-37755e6b0450" />

업무 조회시 파일명도 함께 조회
<img width="2004" height="1048" alt="스크린샷 2025-08-13 162303" src="https://github.com/user-attachments/assets/aa862130-1fe7-473a-877e-00c24b75e450" />

파일 업로드 시 3개 넘으면 에러 
<img width="2118" height="726" alt="스크린샷 2025-08-13 164223" src="https://github.com/user-attachments/assets/3a1954d4-4ac2-4c41-852b-f0e411a7417c" />

## 📎 기타 참고사항

- 
