### PR TITLE
[Feat] 실시간 동기화 기능 구현(comment, cocomment), 업무 상태변경 브로드캐스트 추가

### DIFF
--- a/src/common/response/real-time-response.dto.ts
+++ b/src/common/response/real-time-response.dto.ts
@@ -10,8 +10,14 @@ export enum RealTimeEntity {
     PLAN = 'plan',
     TASK_FILE = 'task_file',
     STEP = 'step',
+    COMMENT = 'comment',
+    COCOMMENT = 'cocomment',
 }
 
+export enum TaskChannel {
+    STATUS_UPDATED = 'task.STATUS_UPDATED',
+    FIELDS_UPDATED = 'task.FIELDS_UPDATED',
+}
 export class RealTimeMessage<T = any> {
     type: RealTimeType; //행동 구분
     entity: RealTimeEntity; //도메인 구분

--- a/src/infra/llm/llm.service.ts
+++ b/src/infra/llm/llm.service.ts
@@ -117,7 +117,10 @@ export class LLMService {
 
     async generateQuestions(inputData: string): Promise<Array<Question>> {
         // 질문 생성 프롬프트를 로드합니다.
-        const questionPrompt = await PromptManager.getPrompt(this.promptLoader, "question.prompt.md")
+        const questionPrompt = await PromptManager.getPrompt(
+            this.promptLoader,
+            'question.prompt.md'
+        );
 
         const structuredLLM = this.questionLLM.withStructuredOutput<Questions>(questionSchema, {
             name: 'questions',
@@ -163,7 +166,10 @@ export class LLMService {
     // 마스터 포트폴리오 AI 생성
     async generateMasterPortfolio(questionData: any, projectData: ProjectData) {
         // 마스터 포트폴리오 프롬프트를 로드합니다.
-        const masterPortfolioPrompt = await PromptManager.getPrompt(this.promptLoader, "master-portfolio.prompt.md")
+        const masterPortfolioPrompt = await PromptManager.getPrompt(
+            this.promptLoader,
+            'master-portfolio.prompt.md'
+        );
 
         const structuredLLM = this.masterPortfolioLLM.withStructuredOutput<MasterPortfolio>(
             masterPortfolioSchema,
@@ -223,7 +229,10 @@ export class LLMService {
             throw new PortfolioCorrectionNotFoundException(correctionId);
         }
 
-        const correctionPrompt = await PromptManager.getPrompt(this.promptLoader, "portfolio-correction.prompt.md")
+        const correctionPrompt = await PromptManager.getPrompt(
+            this.promptLoader,
+            'portfolio-correction.prompt.md'
+        );
 
         const structuredLLM = this.correctionLLM.withStructuredOutput<Correction>(
             correctionSchema,

--- a/src/infra/llm/rag.service.ts
+++ b/src/infra/llm/rag.service.ts
@@ -78,7 +78,10 @@ export class RagService {
 
     // 키워드 추출
     private async extractSearchQuery(qr: QueryRunner, correctionId: number) {
-        const queryExtractionPrompt = await PromptManager.getPrompt(this.promptLoader, "keyword-extract.prompt.md");
+        const queryExtractionPrompt = await PromptManager.getPrompt(
+            this.promptLoader,
+            'keyword-extract.prompt.md'
+        );
 
         const queryExtractor = this.queryLLM.withStructuredOutput<SearchQuery>(searchQuerySchema, {
             name: 'searchQuery',
@@ -149,7 +152,10 @@ export class RagService {
     // 기업 분석 정보 생성
     private async generateCompanyInsights(searchResults: string[]) {
         // RAG 답변 생성을 위한 로직 구현
-        const companyProfilePrompt = await PromptManager.getPrompt(this.promptLoader, "company-profile.prompt.md");
+        const companyProfilePrompt = await PromptManager.getPrompt(
+            this.promptLoader,
+            'company-profile.prompt.md'
+        );
 
         const companyProfile = await companyProfilePrompt
             .pipe(this.ragLLM)

--- a/src/modules/comments/cocomments/cocomments.module.ts
+++ b/src/modules/comments/cocomments/cocomments.module.ts
@@ -4,10 +4,12 @@ import { Cocomment } from './entities/cocomments.entity';
 import { CocommentsController } from './cocomments.controller';
 import { CocommentsService } from './services/cocomments.service';
 import { CocommentRepository } from './repositories/cocoment.repository';
+import { CocommentsListener } from './listener/cocomments.listener';
+import { GateWayModule } from 'src/infra/gateway/gateway.module';
 @Module({
-    imports: [TypeOrmModule.forFeature([Cocomment])],
+    imports: [TypeOrmModule.forFeature([Cocomment]), GateWayModule],
     controllers: [CocommentsController],
-    providers: [CocommentsService, CocommentRepository],
+    providers: [CocommentsService, CocommentRepository, CocommentsListener],
     exports: [CocommentRepository, CocommentsService],
 })
 export class CocommentsModule {}

--- a/src/modules/comments/cocomments/dto/cocomment-payload.dto.ts
+++ b/src/modules/comments/cocomments/dto/cocomment-payload.dto.ts
@@ -1,0 +1,31 @@
+import { Cocomment } from '../entities/cocomments.entity';
+import { User } from 'src/modules/users/entities/users.entity';
+import { UserProfile } from 'src/common/dtos/user-profile.dto';
+
+/** 생성 이벤트용 DTO */
+export class CreatedCocommentDTO {
+    id: number;
+    content: string;
+    user: UserProfile;
+
+    static from(cocomment: Cocomment): CreatedCocommentDTO {
+        const dto = new CreatedCocommentDTO();
+        dto.id = cocomment.id;
+        dto.content = cocomment.content;
+        dto.user = UserProfile.from(cocomment.user as User);
+        return dto;
+    }
+}
+
+/** 업데이트 이벤트용 DTO */
+export class UpdatedCocommentDTO {
+    id: number;
+    content: string;
+
+    static from(cocomment: Cocomment): UpdatedCocommentDTO {
+        const dto = new UpdatedCocommentDTO();
+        dto.id = cocomment.id;
+        dto.content = cocomment.content;
+        return dto;
+    }
+}

--- a/src/modules/comments/cocomments/listener/cocomments.listener.ts
+++ b/src/modules/comments/cocomments/listener/cocomments.listener.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { EventPayloadDto } from 'src/common/dtos/event-payload.dto';
+import { AppGateway } from 'src/infra/gateway/app.gateway';
+import { SubEventType } from 'src/common/enums/sub-event-type.enum';
+import {
+    RealTimeEntity,
+    RealTimeMessage,
+    RealTimeType,
+} from 'src/common/response/real-time-response.dto';
+
+@Injectable()
+export class CocommentsListener {
+    constructor(private readonly gateway: AppGateway) {}
+
+    /** 대댓글 생성 → 업무 상세에 반영 */
+    @OnEvent(`${RealTimeEntity.COCOMMENT}.${RealTimeType.CREATED}`, { async: true })
+    async onTaskCreated(payload: EventPayloadDto) {
+        const detailRoom = `${SubEventType.TASK_DETAIL}:${payload.data.taskId}`;
+        const msg = RealTimeMessage.of(
+            RealTimeType.CREATED,
+            RealTimeEntity.COCOMMENT,
+            payload.data.cocomment
+        );
+        this.gateway.handlePublish(detailRoom, msg);
+    }
+
+    /** 대댓글 수정 → 업무 상세에 반영 */
+    @OnEvent(`${RealTimeEntity.COCOMMENT}.${RealTimeType.UPDATED}`, { async: true })
+    async onTaskUpdated(payload: EventPayloadDto) {
+        const detailRoom = `${SubEventType.TASK_DETAIL}:${payload.data.taskId}`;
+        const msg = RealTimeMessage.of(
+            RealTimeType.UPDATED,
+            RealTimeEntity.COCOMMENT,
+            payload.data.cocomment
+        );
+
+        this.gateway.handlePublish(detailRoom, msg);
+    }
+
+    /** 대댓글 삭제 → 업무 상세에 반영 */
+    @OnEvent(`${RealTimeEntity.COCOMMENT}.${RealTimeType.DELETED}`, { async: true })
+    async onTaskDeleted(payload: EventPayloadDto) {
+        const detailRoom = `${SubEventType.TASK_DETAIL}:${payload.data.taskId}`;
+        const msg = RealTimeMessage.of(RealTimeType.DELETED, RealTimeEntity.COCOMMENT, {
+            id: payload.data.cocommentId,
+        });
+
+        this.gateway.handlePublish(detailRoom, msg);
+    }
+}

--- a/src/modules/comments/cocomments/repositories/cocoment.repository.ts
+++ b/src/modules/comments/cocomments/repositories/cocoment.repository.ts
@@ -57,4 +57,29 @@ export class CocommentRepository {
     ): Promise<Cocomment> {
         return queryRunner.manager.save(Cocomment, cocomment);
     }
+
+    async findByIdWithUserAndTaskForEventUsingQR(
+        qr: QueryRunner,
+        cocommentId: number
+    ): Promise<Cocomment> {
+        const cc = await qr.manager
+            .createQueryBuilder(Cocomment, 'cc')
+            .leftJoinAndSelect('cc.user', 'user')
+            .leftJoinAndSelect('cc.comment', 'comment')
+            .leftJoinAndSelect('comment.task', 'task')
+            .select([
+                'cc.id',
+                'cc.content',
+                'user.id',
+                'user.name',
+                'user.imageUrl',
+                'comment.id',
+                'task.id',
+            ])
+            .where('cc.id = :cocommentId', { cocommentId })
+            .getOne();
+
+        if (!cc) throw new CocommentNotFoundException();
+        return cc;
+    }
 }

--- a/src/modules/comments/cocomments/services/cocomments.service.ts
+++ b/src/modules/comments/cocomments/services/cocomments.service.ts
@@ -7,10 +7,16 @@ import {
 import { CommonResponse } from 'src/common/response/common-response.dto';
 import { QueryRunner } from 'typeorm';
 import { CocommentRepository } from '../repositories/cocoment.repository';
-
+import { UpdatedCocommentDTO } from '../dto/cocomment-payload.dto';
+import { RealTimeEntity, RealTimeType } from 'src/common/response/real-time-response.dto';
+import { EventPayloadDto } from 'src/common/dtos/event-payload.dto';
+import { EventBusService } from 'src/infra/event-bus/event-bus.service';
 @Injectable()
 export class CocommentsService {
-    constructor(private readonly cocommentRepository: CocommentRepository) {}
+    constructor(
+        private readonly cocommentRepository: CocommentRepository,
+        private readonly eventBus: EventBusService
+    ) {}
 
     async updateCocomment(
         queryRunner: QueryRunner,
@@ -18,7 +24,7 @@ export class CocommentsService {
         cocommentId: number,
         dto: UpdateCocommentRequestDto
     ): Promise<UpdateCocommentResponseDto> {
-        const cocomment = await this.cocommentRepository.findByIdWithUserWithQueryRunner(
+        const cocomment = await this.cocommentRepository.findByIdWithUserAndTaskForEventUsingQR(
             queryRunner,
             cocommentId
         );
@@ -29,12 +35,20 @@ export class CocommentsService {
 
         cocomment.content = dto.content;
 
-        const updatedComment = await this.cocommentRepository.saveCocommentWithQueryRunner(
+        const updatedCocomment = await this.cocommentRepository.saveCocommentWithQueryRunner(
             queryRunner,
             cocomment
         );
 
-        return UpdateCocommentResponseDto.from(updatedComment);
+        await this.eventBus.publishAsync(
+            `${RealTimeEntity.COCOMMENT}.${RealTimeType.UPDATED}`,
+            EventPayloadDto.from(RealTimeType.UPDATED, {
+                taskId: cocomment.comment.task.id,
+                cocomment: UpdatedCocommentDTO.from(updatedCocomment),
+            })
+        );
+
+        return UpdateCocommentResponseDto.from(updatedCocomment);
     }
 
     async deleteCocomment(
@@ -43,7 +57,7 @@ export class CocommentsService {
         cocommentId: number
     ): Promise<CommonResponse> {
         // 대댓글 존재 여부 확인
-        const cocomment = await this.cocommentRepository.findByIdWithUserWithQueryRunner(
+        const cocomment = await this.cocommentRepository.findByIdWithUserAndTaskForEventUsingQR(
             queryRunner,
             cocommentId
         );
@@ -55,6 +69,15 @@ export class CocommentsService {
 
         // 대댓글 삭제
         await this.cocommentRepository.deleteCocommentWithQueryRunner(queryRunner, cocommentId);
+
+        //웹소켓 이벤트 발행
+        await this.eventBus.publishAsync(
+            `${RealTimeEntity.COCOMMENT}.${RealTimeType.DELETED}`,
+            EventPayloadDto.from(RealTimeType.DELETED, {
+                taskId: cocomment.comment.task.id,
+                cocommentId,
+            })
+        );
 
         return CommonResponse.success({ message: `대댓글 ID ${cocommentId} 삭제 완료` });
     }

--- a/src/modules/comments/comments.module.ts
+++ b/src/modules/comments/comments.module.ts
@@ -5,11 +5,12 @@ import { CommentsController } from './comments.controller';
 import { CommentsService } from './services/comments.service';
 import { CommentRepository } from './repositories/comments.repository';
 import { CocommentsModule } from './cocomments/cocomments.module';
-
+import { CommentsListener } from './listener/comments.listener';
+import { GateWayModule } from 'src/infra/gateway/gateway.module';
 @Module({
-    imports: [TypeOrmModule.forFeature([Comment]), CocommentsModule],
+    imports: [TypeOrmModule.forFeature([Comment]), CocommentsModule, GateWayModule],
     controllers: [CommentsController],
-    providers: [CommentsService, CommentRepository],
+    providers: [CommentsService, CommentRepository, CommentsListener],
     exports: [CommentRepository, CommentsService],
 })
 export class CommentsModule {}

--- a/src/modules/comments/dto/comment-payload.dto.ts
+++ b/src/modules/comments/dto/comment-payload.dto.ts
@@ -1,0 +1,31 @@
+import { Comment } from '../entities/comments.entity';
+import { User } from 'src/modules/users/entities/users.entity';
+import { UserProfile } from 'src/common/dtos/user-profile.dto';
+
+/** 생성 이벤트용 DTO */
+export class CreatedCommentDTO {
+    id: number;
+    content: string;
+    user: UserProfile;
+
+    static from(comment: Comment): CreatedCommentDTO {
+        const dto = new CreatedCommentDTO();
+        dto.id = comment.id;
+        dto.content = comment.content;
+        dto.user = UserProfile.from(comment.user as User);
+        return dto;
+    }
+}
+
+/** 업데이트 이벤트용 DTO */
+export class UpdatedCommentDTO {
+    id: number;
+    content: string;
+
+    static from(comment: Comment): UpdatedCommentDTO {
+        const dto = new UpdatedCommentDTO();
+        dto.id = comment.id;
+        dto.content = comment.content;
+        return dto;
+    }
+}

--- a/src/modules/comments/listener/comments.listener.ts
+++ b/src/modules/comments/listener/comments.listener.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { EventPayloadDto } from 'src/common/dtos/event-payload.dto';
+import { AppGateway } from 'src/infra/gateway/app.gateway';
+import { SubEventType } from 'src/common/enums/sub-event-type.enum';
+import {
+    RealTimeEntity,
+    RealTimeMessage,
+    RealTimeType,
+} from 'src/common/response/real-time-response.dto';
+
+@Injectable()
+export class CommentsListener {
+    constructor(private readonly gateway: AppGateway) {}
+
+    /** 댓글 생성 → 업무 상세에 반영 */
+    @OnEvent(`${RealTimeEntity.COMMENT}.${RealTimeType.CREATED}`, { async: true })
+    async onTaskCreated(payload: EventPayloadDto) {
+        const detailRoom = `${SubEventType.TASK_DETAIL}:${payload.data.taskId}`;
+        const msg = RealTimeMessage.of(
+            RealTimeType.CREATED,
+            RealTimeEntity.COMMENT,
+            payload.data.comment
+        );
+        this.gateway.handlePublish(detailRoom, msg);
+    }
+
+    /** 댓글 수정 → 업무 상세에 반영 */
+    @OnEvent(`${RealTimeEntity.COMMENT}.${RealTimeType.UPDATED}`, { async: true })
+    async onTaskUpdated(payload: EventPayloadDto) {
+        const detailRoom = `${SubEventType.TASK_DETAIL}:${payload.data.taskId}`;
+        const msg = RealTimeMessage.of(
+            RealTimeType.UPDATED,
+            RealTimeEntity.COMMENT,
+            payload.data.comment
+        );
+
+        this.gateway.handlePublish(detailRoom, msg);
+    }
+
+    /** 댓글 삭제 → 업무 상세에 반영 */
+    @OnEvent(`${RealTimeEntity.COMMENT}.${RealTimeType.DELETED}`, { async: true })
+    async onTaskDeleted(payload: EventPayloadDto) {
+        const detailRoom = `${SubEventType.TASK_DETAIL}:${payload.data.taskId}`;
+        const msg = RealTimeMessage.of(RealTimeType.DELETED, RealTimeEntity.COMMENT, {
+            id: payload.data.commentId,
+        });
+
+        this.gateway.handlePublish(detailRoom, msg);
+    }
+}

--- a/src/modules/comments/repositories/comments.repository.ts
+++ b/src/modules/comments/repositories/comments.repository.ts
@@ -101,4 +101,27 @@ export class CommentRepository {
     async saveCommentWithQueryRunner(queryRunner: QueryRunner, comment: Comment): Promise<Comment> {
         return queryRunner.manager.save(Comment, comment);
     }
+
+    async findByIdWithUserAndTaskForEventUsingQR(
+        queryRunner: QueryRunner,
+        commentId: number
+    ): Promise<Comment> {
+        const comment = await queryRunner.manager
+            .createQueryBuilder(Comment, 'comment')
+            .leftJoinAndSelect('comment.user', 'user')
+            .leftJoin('comment.task', 'task')
+            .select([
+                'comment.id',
+                'comment.content',
+                'user.id',
+                'user.name',
+                'user.imageUrl',
+                'task.id', // <-- 방 라우팅에 필요
+            ])
+            .where('comment.id = :commentId', { commentId })
+            .getOne();
+
+        if (!comment) throw new CommentNotFoundException();
+        return comment;
+    }
 }

--- a/src/modules/comments/services/comments.service.ts
+++ b/src/modules/comments/services/comments.service.ts
@@ -13,12 +13,17 @@ import {
 } from '../cocomments/dto/create-cocomment.dto';
 import { CommentRepository } from '../repositories/comments.repository';
 import { CocommentRepository } from '../cocomments/repositories/cocoment.repository';
+import { RealTimeEntity, RealTimeType } from 'src/common/response/real-time-response.dto';
+import { EventPayloadDto } from 'src/common/dtos/event-payload.dto';
+import { EventBusService } from 'src/infra/event-bus/event-bus.service';
+import { UpdatedCommentDTO } from '../dto/comment-payload.dto';
+import { CreatedCocommentDTO } from '../cocomments/dto/cocomment-payload.dto';
 @Injectable()
 export class CommentsService {
     constructor(
         private readonly commentRepository: CommentRepository,
-
-        private readonly cocommentRepository: CocommentRepository
+        private readonly cocommentRepository: CocommentRepository,
+        private readonly eventBus: EventBusService
     ) {}
 
     async updateComment(
@@ -28,7 +33,7 @@ export class CommentsService {
         dto: UpdateCommentRequestDto
     ): Promise<UpdateCommentResponseDto> {
         // 1. 댓글 존재 여부 확인 (작성자 정보까지 조회)
-        const comment = await this.commentRepository.findByIdWithUserWithQueryRunner(
+        const comment = await this.commentRepository.findByIdWithUserAndTaskForEventUsingQR(
             queryRunner,
             commentId
         );
@@ -47,7 +52,16 @@ export class CommentsService {
             comment
         );
 
-        // 5. DTO 변환 후 반환
+        // 5. 웹소켓 이벤트 발행
+        await this.eventBus.publishAsync(
+            `${RealTimeEntity.COMMENT}.${RealTimeType.UPDATED}`,
+            EventPayloadDto.from(RealTimeType.UPDATED, {
+                taskId: (comment as any).task.id,
+                comment: UpdatedCommentDTO.from(updatedComment),
+            })
+        );
+
+        // 6. DTO 변환 후 반환
         return UpdateCommentResponseDto.from(updatedComment);
     }
 
@@ -57,7 +71,7 @@ export class CommentsService {
         commentId: number
     ): Promise<CommonResponse> {
         // 댓글 존재 여부 확인
-        const comment = await this.commentRepository.findByIdWithUserWithQueryRunner(
+        const comment = await this.commentRepository.findByIdWithUserAndTaskForEventUsingQR(
             queryRunner,
             commentId
         );
@@ -69,6 +83,15 @@ export class CommentsService {
 
         // 댓글 삭제
         await this.commentRepository.deleteCommentWithQueryRunner(queryRunner, commentId);
+
+        //웹소켓 이벤트 발행
+        await this.eventBus.publishAsync(
+            `${RealTimeEntity.COMMENT}.${RealTimeType.DELETED}`,
+            EventPayloadDto.from(RealTimeType.DELETED, {
+                taskId: (comment as any).task.id,
+                commentId,
+            })
+        );
 
         return CommonResponse.success({ message: `댓글 ID ${commentId} 삭제 완료` });
     }
@@ -96,6 +119,20 @@ export class CommentsService {
         const saved = await this.cocommentRepository.saveCocommentWithQueryRunner(
             queryRunner,
             cocomment
+        );
+
+        const withUser = await this.cocommentRepository.findByIdWithUserAndTaskForEventUsingQR(
+            queryRunner,
+            saved.id
+        );
+
+        // 3) publish
+        await this.eventBus.publishAsync(
+            `${RealTimeEntity.COCOMMENT}.${RealTimeType.CREATED}`,
+            EventPayloadDto.from(RealTimeType.CREATED, {
+                taskId: withUser.comment.task.id,
+                cocomment: CreatedCocommentDTO.from(withUser),
+            })
         );
 
         // 4. 응답 반환

--- a/src/modules/tasks/dtos/task-payload.dto.ts
+++ b/src/modules/tasks/dtos/task-payload.dto.ts
@@ -60,3 +60,16 @@ export class UpdatedTaskDTO {
         return dto;
     }
 }
+
+/**업데이트 - 상태 */
+export class UpdatedTaskStatusDTO {
+    id: number;
+    status: Status;
+
+    static from(task: Task): UpdatedTaskStatusDTO {
+        const dto = new UpdatedTaskStatusDTO();
+        dto.id = task.id;
+        dto.status = task.status;
+        return dto;
+    }
+}

--- a/src/modules/tasks/listener/tasks.listener.ts
+++ b/src/modules/tasks/listener/tasks.listener.ts
@@ -29,7 +29,9 @@ export class TasksListener {
     /** 업무 수정 → 대시보드 + 업무 상세에 모두 반영 */
     @OnEvent(`${RealTimeEntity.TASK}.${RealTimeType.UPDATED}`, { async: true })
     async onTaskUpdated(payload: EventPayloadDto) {
-        // payload.data: { projectId, taskId, diff: { name?, status?, deadline?, managers?, stepId? } }
+        // diff 이벤트만 처리
+        if (!payload?.data?.diff) return;
+
         const dashboardRoom = `${SubEventType.PROJECT_DASHBOARD}:${payload.data.projectId}`;
         const detailRoom = `${SubEventType.TASK_DETAIL}:${payload.data.taskId}`;
         const raw = payload.data.diff ?? {};
@@ -71,5 +73,20 @@ export class TasksListener {
         this.gateway.handlePublish(calendarRoom, msg);
         // 상세 페이지 사용자 강제 이탈
         await this.gateway.handleBanUser(payload.data.userId, detailRoom);
+    }
+
+    /** 업무 상태 수정 → 프로젝트 대시보드에만 반영*/
+    @OnEvent(`${RealTimeEntity.TASK}.${RealTimeType.UPDATED}`, { async: true })
+    async onTaskStatusUpdated(payload: EventPayloadDto) {
+        // 상태 전용 이벤트만 처리
+        if (!payload?.data?.task) return;
+
+        const dashboardRoom = `${SubEventType.PROJECT_DASHBOARD}:${payload.data.projectId}`;
+        const msg = RealTimeMessage.of(
+            RealTimeType.UPDATED,
+            RealTimeEntity.TASK,
+            payload.data.task
+        );
+        this.gateway.handlePublish(dashboardRoom, msg);
     }
 }

--- a/src/modules/tasks/services/tasks.service.ts
+++ b/src/modules/tasks/services/tasks.service.ts
@@ -46,8 +46,13 @@ import { TaskFileLimitExceededException } from 'src/common/exceptions/custom.err
 import { EventBusService } from 'src/infra/event-bus/event-bus.service';
 import { RealTimeEntity, RealTimeType } from 'src/common/response/real-time-response.dto';
 import { EventPayloadDto } from 'src/common/dtos/event-payload.dto';
-import { CreatedTaskDTO, UpdatedTaskDTO, DeletedTaskDTO } from '../dtos/task-payload.dto';
-
+import {
+    CreatedTaskDTO,
+    UpdatedTaskDTO,
+    DeletedTaskDTO,
+    UpdatedTaskStatusDTO,
+} from '../dtos/task-payload.dto';
+import { CreatedCommentDTO } from '../../comments/dto/comment-payload.dto';
 @Injectable()
 export class TasksService {
     constructor(
@@ -370,6 +375,20 @@ export class TasksService {
             content: createCommentRequestDto.content,
         });
         const saved = await this.commentRepository.saveCommentWithQueryRunner(queryRunner, comment);
+
+        const withUser = await this.commentRepository.findByIdWithUserAndTaskForEventUsingQR(
+            queryRunner,
+            saved.id
+        );
+
+        // 3) publish
+        await this.eventBus.publishAsync(
+            `${RealTimeEntity.COMMENT}.${RealTimeType.CREATED}`,
+            EventPayloadDto.from(RealTimeType.CREATED, {
+                taskId,
+                comment: CreatedCommentDTO.from(withUser),
+            })
+        );
         // 4. 응답 반환
         return CreateCommentResponseDto.from(saved);
     }
@@ -742,7 +761,16 @@ export class TasksService {
             task
         );
 
-        // 5. DTO 변환 후 반환
+        // 5. publish
+        await this.eventBus.publishAsync(
+            `${RealTimeEntity.TASK}.${RealTimeType.UPDATED}`,
+            EventPayloadDto.from(RealTimeType.UPDATED, {
+                projectId,
+                task: UpdatedTaskStatusDTO.from(updatedTask),
+            })
+        );
+
+        // 6. DTO 변환 후 반환
         return UpdateTaskStatusResponseDto.from(updatedTask);
     }
 


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #314 

## ✅ 작업 내용
- Comment, Cocomment 생성/수정/삭제 시 실시간 이벤트 브로드캐스트
- CommentsListener
    - created → 상세  publish
    - updated →상세  publish
    - deleted → 상세  publish
- CocommentsListener
    - created → 상세  publish
    - updated →상세  publish
    - deleted → 상세  publish
- 업무 상태 변경 projectDashboard에 브로드 캐스트
## 📸 스크린샷
- 댓글생성
<img width="1830" height="774" alt="웹소켓댓글생성" src="https://github.com/user-attachments/assets/7dedfa01-4893-4f8d-9073-f17f5e185312" />

- 댓글수정
<img width="1843" height="667" alt="웹소켓댓글수정" src="https://github.com/user-attachments/assets/bdc1a552-4715-4d12-b53a-056601ab6db1" />

- 댓글삭제
<img width="1851" height="683" alt="웹소켓댓글삭제" src="https://github.com/user-attachments/assets/1c1af1a0-57af-4ef5-a96a-db3ede4374dd" />

- 대댓글생성
<img width="1825" height="753" alt="웹소켓대댓글생성" src="https://github.com/user-attachments/assets/828c4748-ed49-453d-86ec-77736e4e2cb1" />

- 대댓글수정
<img width="1731" height="532" alt="웹소켓대댓글수정" src="https://github.com/user-attachments/assets/4842c079-81a1-4399-b80a-e4f24045eefe" />

- 대댓글삭제
<img width="1801" height="668" alt="웹소켓대댓글삭제" src="https://github.com/user-attachments/assets/38eba8e8-9ee7-4eb1-9e7b-d8dc48cd85b6" />

- 업무상태변경
<img width="1845" height="639" alt="웹소켓업무상태변경" src="https://github.com/user-attachments/assets/9eb9faf7-14f4-4886-9c0c-8e27f0502d38" />

## 📎 기타 참고사항

- TASK.updated 채널을 두 리스너가 동시에 구독해 대시보드로 중복 publish됨.
     - 해결: 리스너에 가드 추가( diff만/status만 처리)로 중복 제거—or 채널을 STATUS_UPDATED/FIELDS_UPDATED로 분리.
