### PR TITLE
[Feat] 포트폴리오 첨삭 조회, 업데이트, 삭제 API 구현

### DIFF
--- a/src/modules/portfolio-corrections/dtos/portfolio-correction.dto.ts
+++ b/src/modules/portfolio-corrections/dtos/portfolio-correction.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdatePortfolioCorrectionDto {
+    @ApiProperty({ description: '포트폴리오 첨삭 제목', example: '수정된 제목 A' })
+    @IsOptional()
+    @IsString()
+    title?: string;
+}

--- a/src/modules/portfolio-corrections/portfolio-corrections.controller.ts
+++ b/src/modules/portfolio-corrections/portfolio-corrections.controller.ts
@@ -67,7 +67,7 @@ export class PortfolioCorrectionsController {
             '사용자의 AI 첨삭 리스트를 조회하는 API입니다. 페이징을 포함하며, 커서는 AI 첨삭 생성일자입니다.',
     })
     @ApiCommonResponseWithPagination(UserPortfolioCorrectionResponseDto)
-    @Get('/me')
+    @Get('me')
     async getUsersPortfolioCorrections(
         @User('id') userId: number,
         @Query(new ValidationPipe({ transform: true })) req: DateCursor
@@ -87,7 +87,7 @@ export class PortfolioCorrectionsController {
         description: '사용자가 선택할 수 있는 프로젝트 리스트를 조회하는 API입니다.',
     })
     @ApiCommonResponseArray(ProjectResponseDto)
-    @Get('/projects')
+    @Get('projects')
     async getSelectableProjects(@User('id') userId: number) {
         return await this.portfolioCorrectionsService.getSelectableProjects(userId);
     }

--- a/src/modules/portfolio-corrections/portfolio-corrections.controller.ts
+++ b/src/modules/portfolio-corrections/portfolio-corrections.controller.ts
@@ -10,6 +10,7 @@ import {
     Req,
     ValidationPipe,
     HttpStatus,
+    Delete,
 } from '@nestjs/common';
 import { PortfolioCorrectionsService } from './services/portfolio-corrections.service';
 import { ApiBody, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
@@ -33,6 +34,7 @@ import { CompanyInsightResponseDto } from './dtos/company-insight-response.dto';
 import { CorrectionResultDto, GetCorrectionResultDto } from './dtos/correction-result.dto';
 import { StatusResponseDto } from './dtos/status-response.dto';
 import { ApiCommonErrorResponses } from 'src/common/decorators/api-common-error-responses.decorator';
+import { UpdatePortfolioCorrectionDto } from './dtos/portfolio-correction.dto';
 
 @ApiTags('PortfolioCorrections')
 @Controller('portfolio-corrections')
@@ -85,9 +87,61 @@ export class PortfolioCorrectionsController {
         description: '사용자가 선택할 수 있는 프로젝트 리스트를 조회하는 API입니다.',
     })
     @ApiCommonResponseArray(ProjectResponseDto)
-    @Get('projects')
+    @Get('/projects')
     async getSelectableProjects(@User('id') userId: number) {
         return await this.portfolioCorrectionsService.getSelectableProjects(userId);
+    }
+
+    @ApiOperation({
+        summary: '포트폴리오 첨삭 수정',
+        description: '사용자가 포트폴리오 첨삭을 수정합니다.',
+    })
+    @ApiParam({ name: 'correctionId', type: Number, description: '포트폴리오 첨삭 ID' })
+    @ApiBody({ type: UpdatePortfolioCorrectionDto })
+    @ApiCommonErrorResponses(HttpStatus.NOT_FOUND, {
+        errorCode: 'PORTFOLIOCORRECTION4041',
+        reason: '포트폴리오 첨삭을 찾을 수 없습니다.',
+    })
+    @Transactional()
+    @Patch(':correctionId')
+    async updatePortfolioCorrection(
+        @Req() req: TransactionalRequest,
+        @Param('correctionId', ParseIntPipe) correctionId: number,
+        @Body() updatePortfolioCorrectionDto: UpdatePortfolioCorrectionDto
+    ) {
+        return await this.portfolioCorrectionsService.updatePortfolioCorrection(
+            req.queryRunner,
+            correctionId,
+            updatePortfolioCorrectionDto
+        );
+    }
+
+    @ApiOperation({
+        summary: '포트폴리오 첨삭 조회',
+        description: '특정 포트폴리오 첨삭의 정보를 조회합니다.',
+    })
+    @ApiParam({ name: 'correctionId', type: Number, description: '포트폴리오 첨삭 ID' })
+    @ApiCommonErrorResponses(HttpStatus.NOT_FOUND, {
+        errorCode: 'PORTFOLIOCORRECTION4041',
+        reason: '포트폴리오 첨삭을 찾을 수 없습니다.',
+    })
+    @Get(':correctionId')
+    async getPortfolioCorrection(@Param('correctionId', ParseIntPipe) correctionId: number) {
+        return await this.portfolioCorrectionsService.getPortfolioCorrection(correctionId);
+    }
+
+    @ApiOperation({
+        summary: '포트폴리오 첨삭 삭제',
+        description: '특정 포트폴리오 첨삭을 삭제합니다.',
+    })
+    @ApiParam({ name: 'correctionId', type: Number, description: '포트폴리오 첨삭 ID' })
+    @ApiCommonErrorResponses(HttpStatus.NOT_FOUND, {
+        errorCode: 'PORTFOLIOCORRECTION4041',
+        reason: '포트폴리오 첨삭을 찾을 수 없습니다.',
+    })
+    @Delete(':correctionId')
+    async deletePortfolioCorrection(@Param('correctionId', ParseIntPipe) correctionId: number) {
+        return await this.portfolioCorrectionsService.deletePortfolioCorrection(correctionId);
     }
 
     @ApiOperation({

--- a/src/modules/portfolio-corrections/services/portfolio-corrections.service.ts
+++ b/src/modules/portfolio-corrections/services/portfolio-corrections.service.ts
@@ -31,6 +31,7 @@ import { RagResponseDto } from '../dtos/rag-response.dto';
 import { StatusResponseDto } from '../dtos/status-response.dto';
 import { ResponseDelayManager } from 'src/common/utils/response-delay.util';
 import { CorrectionResultDto, GetCorrectionResultDto } from '../dtos/correction-result.dto';
+import { UpdatePortfolioCorrectionDto } from '../dtos/portfolio-correction.dto';
 
 async function checkCorrectionExists(qr: QueryRunner, correctionId: number) {
     // correctionId에 해당하는 포트폴리오 첨삭 엔티티가 있는지
@@ -406,5 +407,49 @@ export class PortfolioCorrectionsService {
             where: { portfolioCorrection: { id: correctionId }, projectId: projectId },
         });
         return CorrectionResultDto.from(result);
+    }
+
+    // 포트폴리오 첨삭 업데이트
+    async updatePortfolioCorrection(
+        qr: QueryRunner,
+        correctionId: number,
+        updatePortfolioCorrectionDto: UpdatePortfolioCorrectionDto
+    ) {
+        await checkCorrectionExists(qr, correctionId);
+
+        await qr.manager.update(
+            PortfolioCorrection,
+            {
+                id: correctionId,
+            },
+            {
+                title: updatePortfolioCorrectionDto.title,
+            }
+        );
+
+        return await qr.manager.findOne(PortfolioCorrection, {
+            where: { id: correctionId },
+        });
+    }
+
+    // 포트폴리오 첨삭 조회
+    async getPortfolioCorrection(correctionId: number) {
+        const correction = await this.correctionRepository.findOne({
+            where: { id: correctionId },
+        });
+        if (!correction) {
+            throw new PortfolioCorrectionNotFoundException(correctionId);
+        }
+
+        return PortfolioCorrectionResponseDto.fromEntity(correction);
+    }
+
+    // 포트폴리오 첨삭 삭제
+    async deletePortfolioCorrection(correctionId: number) {
+        const result = await this.correctionRepository.delete({ id: correctionId });
+        if (result.affected === 0) {
+            throw new PortfolioCorrectionNotFoundException(correctionId);
+        }
+        return `포트폴리오 첨삭 id ${correctionId}가 성공적으로 삭제되었습니다.`;
     }
 }

--- a/src/modules/portfolio-corrections/services/portfolio-corrections.service.ts
+++ b/src/modules/portfolio-corrections/services/portfolio-corrections.service.ts
@@ -427,9 +427,10 @@ export class PortfolioCorrectionsService {
             }
         );
 
-        return await qr.manager.findOne(PortfolioCorrection, {
-            where: { id: correctionId },
-        });
+        return {
+            id: correctionId,
+            title: updatePortfolioCorrectionDto.title,
+        };
     }
 
     // 포트폴리오 첨삭 조회


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #321 

## ✅ 작업 내용

- 포트폴리오 첨삭 조회, 업데이트, 삭제 API 구현

## 📸 스크린샷

- 삭제
  <img width="482" height="516" alt="image" src="https://github.com/user-attachments/assets/6bd6257b-3e57-4bda-8dfe-f0dbe2b061ef" />
- 조회
  <img width="491" height="571" alt="image" src="https://github.com/user-attachments/assets/e1b57caa-f61f-4c63-adcf-1f0d859f29e1" />
- 업데이트
  <img width="535" height="554" alt="image" src="https://github.com/user-attachments/assets/1d048ee9-2bfb-410e-bdf3-1b5bc9508ca6" />

## 📎 기타 참고사항

- 나중에는 soft delete로 수정하기