### PR TITLE
[Feat] 로그아웃 기능 구현

### DIFF
--- a/src/common/exceptions/custom.errors.ts
+++ b/src/common/exceptions/custom.errors.ts
@@ -121,6 +121,12 @@ export class UnAuthorizedException extends CustomHttpException {
     }
 }
 
+export class LogoutUserException extends CustomHttpException {
+    constructor(data?: any) {
+        super(ErrorCode.LOGOUT_USER, '로그아웃한 사용자입니다.', HttpStatus.UNAUTHORIZED, data);
+    }
+}
+
 export class APIUnauthorizedException extends CustomHttpException {
     constructor(data?: any) {
         super(

--- a/src/common/exceptions/errorcode.enum.ts
+++ b/src/common/exceptions/errorcode.enum.ts
@@ -5,6 +5,7 @@ export enum ErrorCode {
     INTERNAL_SERVER_ERROR = 'COMMON500',
     TRANSACTION_ERROR = 'COMMON501',
     //사용자
+    LOGOUT_USER = 'USER401',
     USER_NOT_FOUND = 'USER404',
     USER_INVARIANT_VIOLATION = 'AUTH5001',
     //프로젝트

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,13 +1,15 @@
-import { Controller, Get, Query, Req, Res, UseGuards } from '@nestjs/common';
+import { Controller, Get, HttpStatus, Post, Query, Req, Res, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { AuthService } from './services/auth.service';
 import { ConfigService } from '@nestjs/config';
 import { KakaoUser, KakaoUserAfterAuth } from 'src/common/decorators/user.decorator';
-import { Response } from 'express';
-import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Request, Response } from 'express';
+import { ApiOkResponse, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Pulbic } from 'src/common/decorators/public.decorator';
 import { SetRedirectUrlGuard } from './guards/set-redirect-url.guard';
 import { InternalServerError } from 'src/common/exceptions/custom.errors';
+import { ErrorCode } from 'src/common/exceptions/errorcode.enum';
+import { ApiCommonErrorResponses } from 'src/common/decorators/api-common-error-responses.decorator';
 
 @ApiTags('Auth')
 @Controller('/auth')
@@ -89,5 +91,36 @@ export class AuthController {
             //TODO: 추후 refreshToken 구현 필요
             res.redirect(fullRedirect);
         });
+    }
+
+    @ApiOperation({
+        summary: '로그아웃',
+        description: 'JWT 토큰을 만료시키고 서버에서 로그아웃을 수행합니다.',
+    })
+    @ApiOkResponse({
+        schema: {
+            example: {
+                isSuccess: true,
+                error: null,
+                result: 'Logout from Server',
+            },
+        },
+    })
+    @ApiCommonErrorResponses(HttpStatus.UNAUTHORIZED, [
+        { errorCode: ErrorCode.UNAUTHORIZED, reason: '유효하지 않은 사용자입니다.' },
+        { errorCode: ErrorCode.LOGOUT_USER, reason: '로그아웃한 사용자입니다.' },
+    ])
+    @Post('logout')
+    async handleLogout(@Req() req: Request) {
+        const token = req.cookies?.['accessToken'];
+        if (token) {
+            await this.authService.blacklistToken(token);
+        }
+        req.res?.clearCookie('accessToken', {
+            httpOnly: true,
+            secure: true,
+            sameSite: 'none',
+        });
+        return 'Logout from Server';
     }
 }

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -8,6 +8,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { RedisModule } from 'src/infra/redis/redis.module';
 
 @Module({
     imports: [
@@ -23,6 +24,7 @@ import { JwtAuthGuard } from './guards/jwt-auth.guard';
             }),
             inject: [ConfigService],
         }),
+        RedisModule,
     ],
     controllers: [AuthController],
     providers: [AuthService, KakaoStrategy, JwtStrategy, JwtAuthGuard],

--- a/src/modules/auth/guards/jwt-auth.guard.ts
+++ b/src/modules/auth/guards/jwt-auth.guard.ts
@@ -1,13 +1,16 @@
 import { ExecutionContext, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
-import { Observable } from 'rxjs';
 import { IS_PUBLIC_KEY } from 'src/common/decorators/public.decorator';
-import { UnAuthorizedException } from 'src/common/exceptions/custom.errors';
+import { LogoutUserException, UnAuthorizedException } from 'src/common/exceptions/custom.errors';
+import { AuthService } from '../services/auth.service';
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {
-    constructor(private reflector: Reflector) {
+    constructor(
+        private reflector: Reflector,
+        private readonly authService: AuthService
+    ) {
         super();
     }
 
@@ -24,12 +27,21 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
         return user;
     }
 
-    canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
+    async canActivate(context: ExecutionContext): Promise<boolean> {
         const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
             context.getHandler(),
             context.getClass(),
         ]);
         if (isPublic) return true;
-        return super.canActivate(context);
+
+        const request = context.switchToHttp().getRequest();
+        const token = request.cookies?.['accessToken'];
+        // blacklist 체크
+        if (token && (await this.authService.isTokenBlacklisted(token))) {
+            throw new LogoutUserException();
+        }
+
+        const result = (await super.canActivate(context)) as boolean;
+        return result;
     }
 }

--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -1,17 +1,20 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { KakaoUserAfterAuth } from 'src/common/decorators/user.decorator';
 import { UsersService } from '../../users/services/users.service';
 import { JwtService } from '@nestjs/jwt';
 import { UserInvariantViolationException } from 'src/common/exceptions/custom.errors';
 import { WsException } from '@nestjs/websockets';
 import { ConfigService } from '@nestjs/config';
+import { RedisClientType } from 'redis';
 
 @Injectable()
 export class AuthService {
     constructor(
         private readonly userService: UsersService,
         private readonly jwtService: JwtService,
-        private readonly configService: ConfigService
+        private readonly configService: ConfigService,
+        @Inject('REDIS_CLIENT')
+        private readonly redis: RedisClientType
     ) {}
 
     async handleKakaoLogin(kakaoUser: KakaoUserAfterAuth): Promise<String> {
@@ -56,5 +59,18 @@ export class AuthService {
         } catch {
             return false;
         }
+    }
+
+    async blacklistToken(token: string) {
+        const decoded: any = this.jwtService.decode(token);
+        const exp = decoded?.exp || this.configService.get('JWT_EXPIRES_IN') || 1000 * 60 * 60;
+        const ttl = exp - Math.floor(Date.now() / 1000);
+        if (ttl > 0) {
+            await this.redis.set(`blacklist:${token}`, '1', { EX: ttl });
+        }
+    }
+
+    async isTokenBlacklisted(token: string): Promise<boolean> {
+        return !!(await this.redis.get(`blacklist:${token}`));
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #325 

## ✅ 작업 내용

- 로그아웃 API 구현
- JWT를 레디스에 blacklist로 저장 및 만료 처리
- 로그아웃된 사용자에 대해 커스텀 에러 정의

## 📸 스크린샷
**[로그아웃 전]**
<img width="885" height="840" alt="image" src="https://github.com/user-attachments/assets/af54a4a1-5454-4305-a257-b344cd1372eb" />
<img width="778" height="90" alt="image" src="https://github.com/user-attachments/assets/4cc2b8c1-d3c2-4741-a277-45e2067afbac" />

**[로그아웃 후]**
<img width="902" height="807" alt="image" src="https://github.com/user-attachments/assets/ea7a67d8-a278-4971-b932-dc0bf06e1792" />
<img width="782" height="117" alt="image" src="https://github.com/user-attachments/assets/80dac4b1-243b-481c-838f-39b9f2e81500" />

**[로그아웃 후 같은 토큰 사용하여 시도]**
<img width="897" height="806" alt="image" src="https://github.com/user-attachments/assets/f2b0d6e6-4522-4897-b4d4-f5a018f2e026" />

## 📎 기타 참고사항
- 로그아웃 시 브라우저에서 쿠키가 삭제됩니다. 만약 쿠키에 억지로 이전 토큰을 넣더라도 만료 처리되기 때문에 401로 처리됩니다.