### PR TITLE
[Fix] 업무 검색 수정

### DIFF
--- a/src/modules/projects/services/projects.service.ts
+++ b/src/modules/projects/services/projects.service.ts
@@ -241,7 +241,11 @@ export class ProjectsService {
         // 1) 프로젝트 존재 검사 & 수정 가능 확인
         let project = await this.projectRepository.findByProjectIdUsingQR(projectId, qr.manager);
         // 2) 팀장 권한 확인
-        const permission = await this.userProjectRepository.findWithPermission(userId, projectId, qr.manager);
+        const permission = await this.userProjectRepository.findWithPermission(
+            userId,
+            projectId,
+            qr.manager
+        );
         if (!permission || permission !== projectPermission.LEAD) {
             throw new ProjectUpdateForbiddenException('팀장만 프로젝트를 완료할 수 있습니다.');
         }

--- a/src/modules/tasks/repositories/task.repository.ts
+++ b/src/modules/tasks/repositories/task.repository.ts
@@ -5,6 +5,8 @@ import { Task } from '../entities/tasks.entity';
 import { TaskNotFoundException } from 'src/common/exceptions/custom.errors';
 import { QueryRunner } from 'typeorm';
 import { Status } from '../../../common/enums/status.enum';
+import { GetSearchTaskDto } from '../dtos/get-search-task.dto';
+import { Brackets } from 'typeorm';
 
 @Injectable()
 export class TaskRepository {
@@ -46,7 +48,7 @@ export class TaskRepository {
     getProjectTasksBaseQb(projectId: number): SelectQueryBuilder<Task> {
         return this.repo
             .createQueryBuilder('task')
-            .leftJoinAndSelect('task.step', 'step')
+            .leftJoinAndSelect('task.step', 'step', 'step.projectId = :projectId', { projectId })
             .leftJoinAndSelect('task.managers', 'manager')
             .leftJoinAndSelect('manager.user', 'user')
             .where('step.projectId = :projectId', { projectId });
@@ -254,5 +256,152 @@ export class TaskRepository {
             .leftJoinAndSelect('managers.user', 'user')
             .whereInIds(ids)
             .getMany();
+    }
+
+    /* =======================
+     * Task 검색
+     * =======================
+     */
+
+    //BaseQb  + dto 기반 필터 헬퍼 함수 (검색에서 필터링하는 함수)
+    async applySearchFilters(qb: SelectQueryBuilder<Task>, dto: GetSearchTaskDto) {
+        if (dto.statuses?.length) {
+            qb.andWhere('task.status IN (:...statuses)', { statuses: dto.statuses });
+        }
+        if (dto.managerIds?.length) {
+            qb.andWhere('user.id IN (:...managerIds)', { managerIds: dto.managerIds });
+        }
+        // 날짜 필터: 둘 다 ⇒ AND, 하나만 ⇒ 그 하나만
+        if (dto.dateBefore || dto.dateAfter) {
+            qb.andWhere(
+                new Brackets((q) => {
+                    if (dto.dateAfter && dto.dateBefore) {
+                        // AND 범위 필터
+                        q.where('task.deadline >= :dateAfter', {
+                            dateAfter: `${dto.dateAfter} 00:00:00`,
+                        }).andWhere('task.deadline <= :dateBefore', {
+                            dateBefore: `${dto.dateBefore} 23:59:59`,
+                        });
+                    } else if (dto.dateAfter) {
+                        q.where('task.deadline >= :dateAfter', {
+                            dateAfter: `${dto.dateAfter} 00:00:00`,
+                        });
+                    } else if (dto.dateBefore) {
+                        q.where('task.deadline <= :dateBefore', {
+                            dateBefore: `${dto.dateBefore} 23:59:59`,
+                        });
+                    }
+                })
+            );
+        }
+
+        return qb;
+    }
+
+    // --- totalCount (검색 포함)
+    async findCountByProjectIdWithFilters(
+        projectId: number,
+        dto: GetSearchTaskDto
+    ): Promise<number> {
+        const qb = this.getProjectTasksBaseQb(projectId);
+        this.applySearchFilters(qb, dto);
+        return qb.clone().select('task.id').distinct(true).getCount();
+    }
+
+    // 진행 상황별 Top-N (검색 포함)
+    async findTop5SearchByProjectIdAndStatusOrderByDeadlineAsc(
+        projectId: number,
+        status: Status,
+        limit: number,
+        dto: GetSearchTaskDto
+    ): Promise<Task[]> {
+        const qb = this.getProjectTasksBaseQb(projectId); // 공통 베이스
+        this.applySearchFilters(qb, dto); // 검색 필터 적용
+
+        qb.andWhere('task.status = :status', { status }).distinct(true);
+        this.orderByDeadlineNullsLast(qb);
+        qb.take(limit);
+
+        return qb.getMany();
+    }
+
+    // 스텝별 Top-N (검색 포함)
+    async findTop5SearchByProjectIdAndStepOrderByDeadlineAsc(
+        projectId: number,
+        stepId: number,
+        limit: number,
+        dto: GetSearchTaskDto
+    ): Promise<Task[]> {
+        const qb = this.getProjectTasksBaseQb(projectId);
+        this.applySearchFilters(qb, dto);
+
+        qb.andWhere('step.id = :stepId', { stepId }).distinct(true);
+        this.orderByDeadlineNullsLast(qb);
+        qb.take(limit); //  조인 중복 방지
+
+        return qb.getMany();
+    }
+
+    // step별 업무 더보기 (검색 포함)
+    async findSearchByProjectAndStepPaginated(
+        projectId: number,
+        stepId: number,
+        limit: number,
+        offset: number,
+        dto: GetSearchTaskDto
+    ): Promise<{ items: Task[]; totalCount: number }> {
+        // 목록 쿼리
+        const listQb = this.getProjectTasksBaseQb(projectId);
+        this.applySearchFilters(listQb, dto); //  검색 필터 적용
+        listQb.andWhere('step.id = :stepId', { stepId }).distinct(true);
+        this.orderByDeadlineNullsLast(listQb);
+        listQb.skip(offset).take(limit); //  조인 중복 방지
+
+        const items = await listQb.getMany();
+
+        // 전체 개수 (동일 필터 + distinct count)
+        const countQb = this.getProjectTasksBaseQb(projectId);
+        this.applySearchFilters(countQb, dto);
+        countQb.andWhere('step.id = :stepId', { stepId });
+
+        const totalCount = await countQb.clone().select('task.id').distinct(true).getCount();
+
+        return { items, totalCount };
+    }
+
+    // status별 업무 더보기 (검색 포함)
+    async findSearchByProjectAndStatusPaginated(
+        projectId: number,
+        status: Status,
+        limit: number,
+        offset: number,
+        dto: GetSearchTaskDto
+    ): Promise<{ items: Task[]; totalCount: number }> {
+        // 목록 쿼리
+        const listQb = this.getProjectTasksBaseQb(projectId);
+        this.applySearchFilters(listQb, dto);
+        listQb.andWhere('task.status = :status', { status }).distinct(true);
+        this.orderByDeadlineNullsLast(listQb);
+        listQb.skip(offset).take(limit);
+
+        const items = await listQb.getMany();
+
+        // 전체 개수
+        const countQb = this.getProjectTasksBaseQb(projectId);
+        this.applySearchFilters(countQb, dto);
+        countQb.andWhere('task.status = :status', { status });
+
+        const totalCount = await countQb.clone().select('task.id').distinct(true).getCount();
+
+        return { items, totalCount };
+    }
+
+    // 공통 헬퍼
+    private orderByDeadlineNullsLast(qb: SelectQueryBuilder<Task>) {
+        qb.addSelect('CASE WHEN task.deadline IS NULL THEN 1 ELSE 0 END', 'deadline_null_rank')
+            .orderBy('deadline_null_rank', 'ASC')
+            .addOrderBy('task.deadline', 'ASC')
+            .addOrderBy('task.createdAt', 'ASC');
+        return qb;
     }
 }

--- a/src/modules/tasks/services/tasks.service.ts
+++ b/src/modules/tasks/services/tasks.service.ts
@@ -602,54 +602,65 @@ export class TasksService {
 
         await this.projectsService.assertProjectMember(userId, projectId);
 
-        //2) 필터용 baseQb
-        const baseQb = this.buildSearchBaseQb(projectId, dto);
-
-        // 3) 전체 개수
-        const totalCount = await baseQb.getCount();
+        //  전체 개수
+        const totalCount = await this.taskRepository.findCountByProjectIdWithFilters(
+            projectId,
+            dto
+        );
 
         // 4) 그룹별 5개씩 병렬 조회
         if (view === 'status') {
             const statuses = [Status.NOTSTART, Status.ONGOING, Status.COMPLETED];
-            const statusGroups = await Promise.all(
-                statuses.map(async (status) => {
-                    const tasks = await baseQb
-                        .clone() // 이미 모든 조인이 들어있음
-                        .andWhere('task.status = :status', { status })
-                        .orderBy('task.deadline', 'ASC')
-                        .addOrderBy('task.createdAt', 'ASC')
-                        .limit(limit)
-                        .getMany();
+            const statusGroups: { status: Status; tasks: TaskInStatusDto[] }[] = [];
 
-                    return {
+            for (const status of statuses) {
+                const tasks =
+                    await this.taskRepository.findTop5SearchByProjectIdAndStatusOrderByDeadlineAsc(
+                        projectId,
                         status,
-                        tasks: tasks.map(TaskInStatusDto.from),
-                    };
-                })
-            );
+                        limit,
+                        dto
+                    );
 
-            return { projectId, projectName: project.name, statusGroups, totalCount };
+                statusGroups.push({
+                    status,
+                    tasks: tasks.map((task) => TaskInStatusDto.from(task)),
+                });
+            }
+
+            return {
+                projectId: project.id,
+                projectName: project.name,
+                statusGroups,
+                totalCount,
+            };
         } else {
             const steps = await this.stepRepository.findByProjectId(projectId);
 
-            const stepGroups = await Promise.all(
-                steps.map(async (step) => {
-                    const tasks = await baseQb
-                        .clone()
-                        .andWhere('task.stepId = :stepId', { stepId: step.id })
-                        .orderBy('task.deadline', 'ASC')
-                        .addOrderBy('task.createdAt', 'ASC')
-                        .limit(limit)
-                        .getMany();
+            const stepGroups: { stepId: number; stepName: string; tasks: TaskInStepDto[] }[] = [];
 
-                    return {
-                        stepId: step.id,
-                        stepName: step.name,
-                        tasks: tasks.map(TaskInStepDto.from),
-                    };
-                })
-            );
+            for (const step of steps) {
+                const tasks =
+                    await this.taskRepository.findTop5SearchByProjectIdAndStepOrderByDeadlineAsc(
+                        projectId,
+                        step.id,
+                        limit,
+                        dto
+                    );
 
+                stepGroups.push({
+                    stepId: step.id,
+                    stepName: step.name,
+                    tasks: tasks.map((task) => TaskInStepDto.from(task)),
+                });
+            }
+
+            return {
+                projectId: project.id,
+                projectName: project.name,
+                steps: stepGroups,
+                totalCount,
+            };
             return { projectId, projectName: project.name, steps: stepGroups, totalCount };
         }
     }
@@ -671,23 +682,16 @@ export class TasksService {
 
         if (offset < 0) throw new BadRequestException('offset은 0 이상이어야 합니다.');
 
-        const baseQb = this.buildSearchBaseQb(projectId, dto);
+        const tasks = await this.taskRepository.findSearchByProjectAndStepPaginated(
+            projectId,
+            stepId,
+            limit,
+            offset,
+            dto
+        );
+        const totalCount = tasks.totalCount;
 
-        const tasks = await baseQb
-            .clone()
-            .andWhere('task.stepId = :stepId', { stepId })
-            .orderBy('task.deadline', 'ASC')
-            .addOrderBy('task.createdAt', 'ASC')
-            .skip(offset)
-            .take(limit)
-            .getMany();
-
-        const totalCount = await baseQb
-            .clone()
-            .andWhere('task.stepId = :stepId', { stepId })
-            .getCount();
-
-        return { tasks: tasks.map(TaskInStepDto.from), totalCount };
+        return { tasks: tasks.items.map((t) => TaskInStepDto.from(t)), totalCount };
     }
 
     async getSearchMoreTasksByStatus(
@@ -713,23 +717,16 @@ export class TasksService {
 
         if (offset < 0) throw new BadRequestException('offset은 0 이상이어야 합니다.');
 
-        const baseQb = this.buildSearchBaseQb(projectId, dto);
+        const tasks = await this.taskRepository.findSearchByProjectAndStatusPaginated(
+            projectId,
+            status,
+            limit,
+            offset,
+            dto
+        );
+        const totalCount = tasks.totalCount;
 
-        const tasks = await baseQb
-            .clone()
-            .andWhere('task.status = :status', { status })
-            .orderBy('task.deadline', 'ASC')
-            .addOrderBy('task.createdAt', 'ASC')
-            .skip(offset)
-            .take(limit)
-            .getMany();
-
-        const totalCount = await baseQb
-            .clone()
-            .andWhere('task.status = :status', { status })
-            .getCount();
-
-        return { tasks: tasks.map(TaskInStatusDto.from), totalCount };
+        return { tasks: tasks.items.map((t) => TaskInStatusDto.from(t)), totalCount };
     }
 
     async updateTaskStatus(
@@ -772,35 +769,6 @@ export class TasksService {
 
         // 6. DTO 변환 후 반환
         return UpdateTaskStatusResponseDto.from(updatedTask);
-    }
-
-    //BaseQb  + dto 기반 필터 헬퍼 함수 (검색에서 필터링하는 함수)
-    private buildSearchBaseQb(projectId: number, dto: GetSearchTaskDto) {
-        const qb = this.taskRepository.getProjectTasksBaseQb(projectId);
-
-        if (dto.statuses?.length) {
-            qb.andWhere('task.status IN (:...statuses)', { statuses: dto.statuses });
-        }
-        if (dto.managerIds?.length) {
-            qb.andWhere('user.id IN (:...managerIds)', { managerIds: dto.managerIds });
-        }
-        if (dto.dateBefore || dto.dateAfter) {
-            qb.andWhere(
-                new Brackets((q) => {
-                    if (dto.dateBefore) {
-                        q.where('task.deadline <= :dateBefore', {
-                            dateBefore: `${dto.dateBefore} 23:59:59`,
-                        });
-                    }
-                    if (dto.dateAfter) {
-                        q.orWhere('task.deadline >= :dateAfter', {
-                            dateAfter: `${dto.dateAfter} 00:00:00`,
-                        });
-                    }
-                })
-            );
-        }
-        return qb;
     }
 }
 


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #329 

## ✅ 작업 내용

- 검색 필터링 제대로 적용되도록 수정
- 검색 필터링 함수 repository로 이동 후 리팩토링
- deadline 로직 수정
- 응답에서 task 배열 안보이던 것 보이도록 수정
- 첫 검색 시 5개까지 보이도록 수정

## 📸 스크린샷

일자를 두 개 다 지정했을 시 AND 적용

<img width="1784" height="1430" alt="스크린샷 2025-08-15 131151" src="https://github.com/user-attachments/assets/e77a4383-5e2d-4df2-be92-9f99bc79d867" />


일자 하나만 지정 시 OR 적용

<img width="1784" height="1265" alt="스크린샷 2025-08-15 131225" src="https://github.com/user-attachments/assets/8c530fd6-a8c2-4e7b-9289-ad840a206c62" />

<img width="1819" height="1412" alt="스크린샷 2025-08-15 131255" src="https://github.com/user-attachments/assets/f2997df0-a8f6-4f26-8ecd-184293d97c4b" />


더보기도 똑같이 적용

<img width="1778" height="1399" alt="스크린샷 2025-08-15 131357" src="https://github.com/user-attachments/assets/6611ad94-1f7d-4ec1-b9bc-932156790613" />

<img width="1699" height="1418" alt="스크린샷 2025-08-15 131430" src="https://github.com/user-attachments/assets/b8abe01e-e486-4411-8163-39ccb3b1670c" />


## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.
