### PR TITLE
[Fix] 겹치는 엔드포인트 수정

### DIFF
--- a/src/modules/portfolio-corrections/portfolio-corrections.controller.ts
+++ b/src/modules/portfolio-corrections/portfolio-corrections.controller.ts
@@ -266,7 +266,7 @@ export class PortfolioCorrectionsController {
             reason: 'AI 첨삭 결과를 찾을 수 없습니다.',
         },
     ])
-    @Get(':correctionId')
+    @Get(':correctionId/results')
     async getCorrection(@Param('correctionId', ParseIntPipe) correctionId: number) {
         return await this.portfolioCorrectionsService.getCorrection(correctionId);
     }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #334 

## ✅ 작업 내용

- 겹치는 엔드포인트 수정 ( `/{correctionId}`에서 `/{correctionId}/results`로 )

## 📸 스크린샷

<img width="763" height="874" alt="image" src="https://github.com/user-attachments/assets/c7209943-a488-48f7-8328-4c42704355cb" />

## 📎 기타 참고사항
