### PR TITLE
[Fix] 나의 프로젝트 및 업무 조회 로직 수정

### DIFF
--- a/src/modules/projects/services/projects.service.ts
+++ b/src/modules/projects/services/projects.service.ts
@@ -580,13 +580,13 @@ export class ProjectsService {
     }
 
     //프로젝트 종료 여부 조회
-    async isCompleted(userId: number, projectId: number): Promise<getProjectIsCompleted>  {
+    async isCompleted(userId: number, projectId: number): Promise<getProjectIsCompleted> {
         // 프로젝트 멤버 권한 검사
         await this.assertProjectMember(userId, projectId);
 
         //프로젝트 종료 여부 검사
         const isCompleted = await this.projectRepository.findIsCompletedByProjectId(projectId);
-        
-        return { isCompleted};
+
+        return { isCompleted };
     }
 }

--- a/src/modules/projects/user-projects/repositories/user-project.repository.ts
+++ b/src/modules/projects/user-projects/repositories/user-project.repository.ts
@@ -43,7 +43,7 @@ export class UserProjectRepository {
 
     async findAllWithProjectByUserId(userId: number) {
         return await this.userProjectRepository.find({
-            where: { user: { id: userId } },
+            where: { user: { id: userId }, project: { isCompleted: false } },
             relations: ['project'],
             select: {
                 project: {

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -98,11 +98,12 @@ export class UsersController {
 
     @ApiOperation({
         summary: '나의 프로젝트 조회',
-        description: '사용자가 속한 프로젝트의 id,이름,프로젝트 내 역할을 반환하는 API입니다.',
+        description:
+            '사용자가 속한 프로젝트의 id, 이름, 프로젝트 내 역할을 반환하는 API입니다. 완료되지 않은 프로젝트만을 반환합니다.',
     })
     @ApiCommonResponse(UserProjectResponseDto)
     @Get('/me/projects')
-    async getUserProject(@User('id') userId: number) {
+    async getUserProject(@User('id') userId: number): Promise<UserProjectResponseDto[]> {
         return await this.userService.getUserProject(userId);
     }
 


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #343 

## ✅ 작업 내용

- 종료된 프로젝트에 대해서는 조회되지 않도록 쿼리 수정

## 📸 스크린샷
**[테스트 데이터]**

> 사용자 1로 로그인
<img width="436" height="180" alt="image" src="https://github.com/user-attachments/assets/018ea84d-a12e-43b3-b76d-3d0f140020a4" />
<img width="302" height="202" alt="image" src="https://github.com/user-attachments/assets/ad0cd3d7-2577-43cd-900c-a71beab083a0" />

**[나의 프로젝트 조회]**
<img width="860" height="686" alt="image" src="https://github.com/user-attachments/assets/b7306535-005d-4f5b-8e9e-0a7c273e2a91" />

**[나의 업무 조회]**
<img width="857" height="850" alt="image" src="https://github.com/user-attachments/assets/df80c698-a643-4b4a-8ecf-c8bac19aed70" />

## 📎 기타 참고사항
