### PR TITLE
[Fix] rag 조회 데이터에 제목 추가

### DIFF
--- a/src/modules/portfolio-corrections/dtos/rag-response.dto.ts
+++ b/src/modules/portfolio-corrections/dtos/rag-response.dto.ts
@@ -12,18 +12,17 @@ export class RagResponseDto {
     keywords: string[];
 
     @ApiProperty({
-        description: '관련 링크 목록',
+        description: '관련 제목/링크 목록',
         example: [
-            'https://kstd-lezhin.career.greetinghr.com/ko/o/143445',
-            'https://www.wanted.co.kr/wd/247334',
-            'https://dealsitetv.com/articles/51996',
-            'https://about.lezhin.com/ko',
+            { title: '원티드', url: 'https://www.wanted.co.kr/wd/247334' },
+            { title: '딜사이트TV', url: 'https://dealsitetv.com/articles/51996' },
+            { title: '레진코믹스', url: 'https://about.lezhin.com/ko' },
         ],
         isArray: true,
         type: String,
     })
     @IsArray()
-    links: string[];
+    links: { title: string; url: string }[];
 
     static fromEntity(entity: any): any {
         const dto = new RagResponseDto();

--- a/src/modules/portfolio-corrections/services/portfolio-corrections.service.ts
+++ b/src/modules/portfolio-corrections/services/portfolio-corrections.service.ts
@@ -288,12 +288,12 @@ export class PortfolioCorrectionsService {
             where: { portfolioCorrection: { id: correctionId } },
         });
         const keywords: string[] = [];
-        const links: string[] = [];
+        const links: { title: string; url: string }[] = [];
         ragData.forEach((item) => {
             if (item.type === RAGDataType.KEYWORD) {
                 keywords.push(item.keyword);
             } else if (item.type === RAGDataType.LINK) {
-                links.push(item.link);
+                links.push({ title: item.title, url: item.link });
             }
         });
         const result = {


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #347 

## ✅ 작업 내용

- rag 조회 데이터에 제목 추가

## 📸 스크린샷

<img width="544" height="866" alt="image" src="https://github.com/user-attachments/assets/5093f729-de4c-4ecf-96fb-bc4abe4fb276" />

## 📎 기타 참고사항
