### PR TITLE
[Fix] 팀 캘린더 조회 범위 확장

### DIFF
--- a/src/common/exceptions/custom.errors.ts
+++ b/src/common/exceptions/custom.errors.ts
@@ -24,7 +24,7 @@ export class InvalidDateException extends CustomHttpException {
     constructor(data?: any) {
         super(
             ErrorCode.PLAN_DATE_TOO_LONG,
-            '최대 31일까지만 조회할 수 있습니다.',
+            '최대 45일까지만 조회할 수 있습니다.',
             HttpStatus.BAD_REQUEST,
             data
         );

--- a/src/modules/projects/projects.controller.ts
+++ b/src/modules/projects/projects.controller.ts
@@ -333,7 +333,7 @@ export class ProjectsController {
     @ApiCommonResponseArray(TeamCalenderResponseDto)
     @ApiCommonErrorResponse(
         ErrorCode.PLAN_DATE_TOO_LONG,
-        '최대 31일까지만 조회할 수 있습니다.',
+        '최대 45일까지만 조회할 수 있습니다.',
         HttpStatus.BAD_REQUEST
     )
     @ApiCommonErrorResponse(
@@ -344,7 +344,6 @@ export class ProjectsController {
     @UseGuards(ProjectMemberGuard)
     @Get('/:projectId/plans')
     async getTeamCalender(
-        @User('id') userId: number,
         @Param('projectId', ParseIntPipe) projectId: number,
         @Query(new ValidationPipe({ transform: true })) query: CalenderQueryDto
     ) {

--- a/src/modules/projects/services/projects.service.ts
+++ b/src/modules/projects/services/projects.service.ts
@@ -443,14 +443,14 @@ export class ProjectsService {
     }
 
     async getTeamCalender(projectId: number, startDate: string, endDate: string) {
-        //검색 범위 제한 - 최대 31일
+        //검색 범위 제한 - 최대 45일
         const start = new Date(startDate);
         const end = new Date(endDate);
 
         const diffInMs = end.getTime() - start.getTime();
         const diffInDays = diffInMs / (1000 * 60 * 60 * 24);
 
-        if (diffInDays > 31) {
+        if (diffInDays > 45) {
             throw new InvalidDateException({
                 startDate: startDate,
                 endDate: endDate,


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #352 

## ✅ 작업 내용

- 기획의도에 따라 조회 범위를 31일로부터 45일로 확장함.

## 📸 스크린샷
<img width="856" height="867" alt="image" src="https://github.com/user-attachments/assets/ccbb55a7-15c3-44fc-924d-fb02c69a9945" />

## 📎 기타 참고사항

- 조회 범위를 환경변수로 관리하는게 낫나 고민해봤는데, 이 부분은 추후 수정이 잦지 않을 것 같아 그냥 두기로 결정했습니다.
