### PR TITLE
[Feat] 사용자 인증/인가 과정에 리프레시 토큰 적용

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -77,7 +77,10 @@ export class AuthController {
 
         // 사용자 인증 by JWT
         const kakaoUser = user;
-        const accessToken = await this.authService.handleKakaoLogin(qr, kakaoUser);
+        const { accessToken, refreshToken } = await this.authService.handleKakaoLogin(
+            qr,
+            kakaoUser
+        );
         req.session.destroy((err: Error) => {
             if (err) {
                 throw new InternalServerError('세션 파괴 중 에러 발생');
@@ -92,9 +95,14 @@ export class AuthController {
                 httpOnly: true,
                 secure: true,
                 sameSite: 'none',
-                maxAge: this.configService.get('JWT_EXPIRES_IN') || 1000 * 60 * 60, // 1시간
+                maxAge: 1000 * (this.configService.get('JWT_EXPIRES_IN') || 60 * 60), // 1시간
             });
-            //TODO: 추후 refreshToken 구현 필요
+            res.cookie('refreshToken', refreshToken, {
+                httpOnly: true,
+                secure: true,
+                sameSite: 'none',
+                maxAge: 1000 * (this.configService.get('JWT_REFRESH_EXPIRES_IN') || 60 * 60 * 24), // 1일
+            });
             res.redirect(fullRedirect);
         });
     }
@@ -118,11 +126,20 @@ export class AuthController {
     ])
     @Post('logout')
     async handleLogout(@Req() req: Request) {
-        const token = req.cookies?.['accessToken'];
-        if (token) {
-            await this.authService.blacklistToken(token);
+        const accessToken = req.cookies?.['accessToken'];
+        const refreshToken = req.cookies?.['refreshToken'];
+        if (accessToken) {
+            await this.authService.blacklistToken(accessToken);
+        }
+        if (refreshToken) {
+            await this.authService.revokeRefreshToken(refreshToken);
         }
         req.res?.clearCookie('accessToken', {
+            httpOnly: true,
+            secure: true,
+            sameSite: 'none',
+        });
+        req.res?.clearCookie('refreshToken', {
             httpOnly: true,
             secure: true,
             sameSite: 'none',

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -11,6 +11,7 @@ import { InternalServerError } from 'src/common/exceptions/custom.errors';
 import { Transactional, TransactionalRequest } from 'src/common/decorators/transaction.decorator';
 import { ErrorCode } from 'src/common/exceptions/errorcode.enum';
 import { ApiCommonErrorResponses } from 'src/common/decorators/api-common-error-responses.decorator';
+import { ApiCommonErrorResponse } from 'src/common/response/swagger-response.helper';
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -105,6 +106,39 @@ export class AuthController {
             });
             res.redirect(fullRedirect);
         });
+    }
+
+    @ApiOperation({
+        summary: '토큰 재발급',
+        description: '유효한 refreshToken을 사용해 accessToken을 재발급 받습니다.',
+    })
+    @ApiOkResponse({
+        schema: {
+            example: {
+                isSuccess: true,
+                error: null,
+                result: 'Generate New AccessToken',
+            },
+        },
+    })
+    @ApiCommonErrorResponse(
+        ErrorCode.UNAUTHORIZED,
+        '유효하지 않은 사용자입니다.',
+        HttpStatus.UNAUTHORIZED
+    )
+    @Pulbic()
+    @Post('refresh')
+    async handleRefresh(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
+        const refreshToken = req.cookies?.['refreshToken'];
+        const accessToken = await this.authService.refreshAccessToken(refreshToken);
+        // 재발급한 액세스토큰으로 쿠키 교체
+        res.cookie('accessToken', accessToken, {
+            httpOnly: true,
+            secure: true,
+            sameSite: 'none',
+            maxAge: 1000 * (this.configService.get('JWT_EXPIRES_IN') || 60 * 60), // 1시간
+        });
+        return 'Generate New AccessToken';
     }
 
     @ApiOperation({

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -19,7 +19,7 @@ import { RedisModule } from 'src/infra/redis/redis.module';
             useFactory: async (configService: ConfigService) => ({
                 secret: configService.get<string>('JWT_SECRET'),
                 signOptions: {
-                    expiresIn: configService.get<string>('JWT_EXPIRES_IN'),
+                    expiresIn: configService.get<number>('JWT_EXPIRES_IN') || 60 * 60,
                 },
             }),
             inject: [ConfigService],

--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -10,6 +10,7 @@ import { WsException } from '@nestjs/websockets';
 import { ConfigService } from '@nestjs/config';
 import { QueryRunner } from 'typeorm';
 import { RedisClientType } from 'redis';
+import * as crypto from 'crypto';
 
 @Injectable()
 export class AuthService {
@@ -21,7 +22,10 @@ export class AuthService {
         private readonly redis: RedisClientType
     ) {}
 
-    async handleKakaoLogin(qr: QueryRunner, kakaoUser: KakaoUserAfterAuth): Promise<String> {
+    async handleKakaoLogin(
+        qr: QueryRunner,
+        kakaoUser: KakaoUserAfterAuth
+    ): Promise<{ accessToken: string; refreshToken: string }> {
         try {
             //1. DB에 사용자가 있는지 확인
             const user = await this.userService.findUserByKakaoId(qr, kakaoUser.id);
@@ -35,18 +39,38 @@ export class AuthService {
             if (!userId) {
                 throw new UserInvariantViolationException();
             }
-            return this.generateAccessToken(userId!);
+            const accessToken = await this.generateAccessToken(userId);
+            const refreshToken = await this.generateRefreshToken(userId);
+            return { accessToken, refreshToken };
         } catch (err) {
             console.log(err);
             throw new TransactionException('Auth');
         }
     }
 
-    generateAccessToken(userId: number): string {
+    async generateAccessToken(userId: number): Promise<string> {
         const payload = {
             userId: userId,
         };
         return this.jwtService.sign(payload);
+    }
+
+    async generateRefreshToken(userId: number): Promise<string> {
+        const tokenId = crypto.randomUUID();
+        const payload = {
+            userId: userId,
+            tokenId: tokenId,
+        };
+
+        const exp = this.configService.get<number>('JWT_REFRESH_EXPIRES_IN') || 60 * 60 * 24; //NOTE: 1d
+        const refreshToken = this.jwtService.sign(payload, {
+            secret: this.configService.get<string>('JWT_REFRESH_SECRET'),
+            expiresIn: exp,
+        });
+
+        const hashedToken = crypto.createHash('sha256').update(refreshToken).digest('hex');
+        await this.redis.set(`refreshToken:${userId}:${tokenId}`, hashedToken, { EX: exp });
+        return refreshToken;
     }
 
     async verifyWsToken(token: string): Promise<number> {
@@ -56,6 +80,38 @@ export class AuthService {
         } catch (err) {
             throw new WsException('Invalid token');
         }
+    }
+
+    async verifyRefreshToken(refreshToken: string) {
+        const payload = await this.jwtService.verifyAsync(refreshToken);
+        const storedHash = await this.redis.get(
+            `refreshToken:${payload.userId}:${payload.tokenId}`
+        );
+        if (!storedHash) return false;
+
+        const hash = crypto.createHash('sha256').update(refreshToken).digest('hex');
+        return hash === storedHash;
+    }
+
+    // 리프레시 토큰 무효화
+    async revokeRefreshToken(refreshToken: string) {
+        const payload = await this.jwtService.verifyAsync(refreshToken, {
+            secret: this.configService.get<string>('JWT_REFRESH_SECRET'),
+        });
+        await this.redis.del(`refreshToken:${payload.userId}:${payload.tokenId}`);
+    }
+
+    async blacklistToken(token: string) {
+        const decoded: any = this.jwtService.decode(token);
+        const exp = decoded?.exp || this.configService.get('JWT_EXPIRES_IN') || 60 * 60;
+        const ttl = Math.floor(exp - Date.now() / 1000);
+        if (ttl > 0) {
+            await this.redis.set(`blacklist:${token}`, '1', { EX: ttl });
+        }
+    }
+
+    async isTokenBlacklisted(token: string): Promise<boolean> {
+        return !!(await this.redis.get(`blacklist:${token}`));
     }
 
     validateRedirectOrigin(url: string): boolean {
@@ -68,18 +124,5 @@ export class AuthService {
         } catch {
             return false;
         }
-    }
-
-    async blacklistToken(token: string) {
-        const decoded: any = this.jwtService.decode(token);
-        const exp = decoded?.exp || this.configService.get('JWT_EXPIRES_IN') || 1000 * 60 * 60;
-        const ttl = exp - Math.floor(Date.now() / 1000);
-        if (ttl > 0) {
-            await this.redis.set(`blacklist:${token}`, '1', { EX: ttl });
-        }
-    }
-
-    async isTokenBlacklisted(token: string): Promise<boolean> {
-        return !!(await this.redis.get(`blacklist:${token}`));
     }
 }

--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -4,6 +4,7 @@ import { UsersService } from '../../users/services/users.service';
 import { JwtService } from '@nestjs/jwt';
 import {
     TransactionException,
+    UnAuthorizedException,
     UserInvariantViolationException,
 } from 'src/common/exceptions/custom.errors';
 import { WsException } from '@nestjs/websockets';
@@ -48,6 +49,20 @@ export class AuthService {
         }
     }
 
+    async refreshAccessToken(refreshToken: string): Promise<string> {
+        if (!refreshToken) throw new UnAuthorizedException('리프레시 토큰이 존재하지 않음.');
+        const payload = await this.jwtService.verifyAsync(refreshToken, {
+            secret: this.configService.get<string>('JWT_REFRESH_SECRET'),
+        });
+        const isValid = await this.verifyRefreshToken(
+            refreshToken,
+            payload.userId,
+            payload.tokenId
+        );
+        if (!isValid) throw new UnAuthorizedException('리프레시 토큰이 만료됨.');
+        return await this.generateAccessToken(payload.userId);
+    }
+
     async generateAccessToken(userId: number): Promise<string> {
         const payload = {
             userId: userId,
@@ -82,11 +97,8 @@ export class AuthService {
         }
     }
 
-    async verifyRefreshToken(refreshToken: string) {
-        const payload = await this.jwtService.verifyAsync(refreshToken);
-        const storedHash = await this.redis.get(
-            `refreshToken:${payload.userId}:${payload.tokenId}`
-        );
+    async verifyRefreshToken(refreshToken: string, userId: number, tokenId: number) {
+        const storedHash = await this.redis.get(`refreshToken:${userId}:${tokenId}`);
         if (!storedHash) return false;
 
         const hash = crypto.createHash('sha256').update(refreshToken).digest('hex');


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #35 

## ✅ 작업 내용

- 로그인 및 로그아웃 시 리프레시 토큰 발급 및 만료 처리
- 리프레시토큰을 해시로 암호화하여 레디스에 저장 >> 보안 강화
- 리프레시토큰을 통한 액세스토큰 재발급 API 구현

## 📸 스크린샷
**[테스트 케이스]**
> TC-001: `auth/kakao` 호출 시 카카오 소셜 로그인 처리 및 쿠키에 { accessToken, refreshToken } 발급
> TC-002: refreshToken이 유효할 때, `auth/refresh`로 accessToken 재발급 가능 (200)
> TC-003: `auth/logout` 호출 시, 리프레시토큰 및 액세스토큰 만료 처리 **in Redis**
> TC-004: refreshToken이 유효하지 않을 때, `auth/refresh`로 accessToken 재발급 불가 (401)

**[TC001 - 로그인]**
<img width="1775" height="482" alt="image" src="https://github.com/user-attachments/assets/28355932-e6da-46c4-8d42-de34839d278d" />
<img width="1891" height="722" alt="image" src="https://github.com/user-attachments/assets/7970ce27-dd56-446a-9763-50fc0251d132" />

**[TC002 - 재발급(200)]**
<img width="1901" height="796" alt="image" src="https://github.com/user-attachments/assets/88cbf3b8-e3f3-4940-9bf9-5b44d4813f6d" />

**[TC003 - 로그아웃]**
<img width="1893" height="763" alt="image" src="https://github.com/user-attachments/assets/0301bff7-c566-4d58-8fbe-6260c64a1486" />
<img width="782" height="117" alt="image" src="https://github.com/user-attachments/assets/512e96f2-8ca1-4a6d-b167-1916c1023fa7" />

**[TC004 - 재발급(401)]**
<img width="1883" height="651" alt="image" src="https://github.com/user-attachments/assets/fcd6b4a9-cc96-4208-a7db-1e550f6a1034" />

## 📎 기타 참고사항

- .env에 `JWT_REFRESH_SECRET` 환경변수 추가되었습니다~
- 테스트에는 포함되지 않았지만, 만료된 리프레시토큰이나 로그아웃 되어 레디스에서 삭제된 리프레시토큰에 대해서는 다음과 같이 에러를 내려주고 있습니다.
```json
{
  "isSuccess": false,
  "error": {
    "errorCode": "COMMON401",
    "reason": "유효하지 않은 사용자입니다.",
    "data": "리프레시 토큰이 만료됨."
  },
  "result": null
}
```
