### PR TITLE
[Feat] AI 첨삭 대상 마스터 포트폴리오 조회 API 구현

### DIFF
--- a/src/common/types/master-portfolio.type.ts
+++ b/src/common/types/master-portfolio.type.ts
@@ -4,3 +4,23 @@ export interface MasterPortfolioOutput {
     keyAchievement: string;
     insight: string;
 }
+
+export interface InputPortfolio {
+    projectName?: string;
+    detailInfo: string;
+    assignedTask: string;
+    keyAchievement: string;
+    insight: string;
+}
+export interface OutputPortfolio {
+    detailInfo: OutputItem[];
+    assignedTask: OutputItem[];
+    keyAchievement: OutputItem[];
+    insight: OutputItem[];
+}
+
+export interface OutputItem {
+    type: 'line' | 'header';
+    number?: number;
+    text: string;
+}

--- a/src/common/utils/transformMasterPortfolio.util.ts
+++ b/src/common/utils/transformMasterPortfolio.util.ts
@@ -1,0 +1,67 @@
+import { InternalServerError } from '../exceptions/custom.errors';
+import { InputPortfolio, OutputItem, OutputPortfolio } from '../types/master-portfolio.type';
+
+// 문자열을 줄 단위로 분할하고 빈 줄을 제거하는 함수
+function splitToLines(text: string): string[] {
+    return text
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+}
+
+function transformField(text: string): OutputItem[] {
+    const lines = splitToLines(text);
+    const result: OutputItem[] = [];
+    let lineNumber = 1;
+
+    for (const line of lines) {
+        result.push({
+            type: 'line',
+            number: lineNumber++,
+            text: line,
+        });
+    }
+    return result;
+}
+
+function transformFieldWithHeader(text: string): OutputItem[] {
+    const lines = splitToLines(text);
+    const result: OutputItem[] = [];
+    let lineNumber = 1;
+
+    for (const line of lines) {
+        // 대괄호로 감싸진 줄인지
+        const headerMatch = line.match(/^\[([^\]]+)\]$/);
+        if (headerMatch) {
+            result.push({
+                type: 'header',
+                text: line,
+            });
+        } else {
+            result.push({
+                type: 'line',
+                number: lineNumber++,
+                text: line,
+            });
+        }
+    }
+    return result;
+}
+
+export class TransformMasterPortfolioUtil {
+    static transformMasterPortfolio(masterPortfolio: InputPortfolio): OutputPortfolio {
+        try {
+            const result: OutputPortfolio = {
+                detailInfo: transformField(masterPortfolio.detailInfo),
+                assignedTask: transformFieldWithHeader(masterPortfolio.assignedTask),
+                keyAchievement: transformField(masterPortfolio.keyAchievement),
+                insight: transformField(masterPortfolio.insight),
+            };
+            return result;
+        } catch (error) {
+            throw new InternalServerError(
+                `포트폴리오 변환 중 오류 발생: ${error instanceof Error ? error.message : '알 수 없는 오류'}`
+            );
+        }
+    }
+}

--- a/src/modules/portfolio-corrections/dtos/master-portfolio-output.dto.ts
+++ b/src/modules/portfolio-corrections/dtos/master-portfolio-output.dto.ts
@@ -1,0 +1,128 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class OutputItemDto {
+    @ApiProperty({ enum: ['line', 'header'], example: 'line' })
+    type: 'line' | 'header';
+
+    @ApiProperty({ required: false, example: 1 })
+    number?: number;
+
+    @ApiProperty({ example: '텍스트 내용' })
+    text: string;
+}
+
+export class MasterPortfolioOutputDto {
+    @ApiProperty({
+        type: OutputItemDto,
+        isArray: true,
+        example: [
+            {
+                type: 'line',
+                number: 1,
+                text: '언어 학습의 한계를 넘어 실제적 표현과 문화 이해를 돕는 교류 환경 조성 목표',
+            },
+            {
+                type: 'line',
+                number: 2,
+                text: '총 9명의 운영진(회장단 2, 기획국 3, 홍보국 2, 대외협력국 2)이 1년간 협업하여 운영',
+            },
+            {
+                type: 'line',
+                number: 3,
+                text: '대상: 언어 교환 및 문화 교류에 관심 있는 동아리 회원',
+            },
+            {
+                type: 'line',
+                number: 4,
+                text: '구글 폼, 구글 시트 등을 활용하여 참가자 수요 기반의 맞춤형 프로그램 기획 및 운영',
+            },
+            {
+                type: 'line',
+                number: 5,
+                text: '정기적인 피드백 수집 및 분석을 통해 차기 활동에 반영하는 데이터 기반 개선 루프 구축',
+            },
+        ],
+    })
+    detailInfo: OutputItemDto[];
+
+    @ApiProperty({
+        type: OutputItemDto,
+        isArray: true,
+        example: [
+            { type: 'header', text: '[동아리 운영 기획 총괄]' },
+            {
+                type: 'line',
+                number: 1,
+                text: '연간 활동계획 및 예산안 수립, 상반기 결산 보고 및 최종 운영보고 진행',
+            },
+            {
+                type: 'line',
+                number: 2,
+                text: '정기모임(월 1회) 및 특별행사(분기 1회)의 전체 예산 관리 및 회계 처리 총괄',
+            },
+            { type: 'header', text: '[정기/특별 행사 기획 및 실행]' },
+            {
+                type: 'line',
+                number: 3,
+                text: "'나의 언어 취향 찾기', '언어 교환 X 퀴즈의 밤' 등 회차별 테마 및 콘텐츠 기획",
+            },
+            {
+                type: 'line',
+                number: 4,
+                text: '참여자 만족도 극대화를 위한 프로그램 상세 설계 (활동지, 아이스브레이킹, BGM 등)',
+            },
+        ],
+    })
+    assignedTask: OutputItemDto[];
+
+    @ApiProperty({
+        type: OutputItemDto,
+        isArray: true,
+        example: [
+            { type: 'line', number: 1, text: '평균 행사 참여율 전년 대비 104.2% 달성' },
+            {
+                type: 'line',
+                number: 2,
+                text: '동아리 회원 유지율 27.1% 달성 (목표치 25% 초과 달성)',
+            },
+            {
+                type: 'line',
+                number: 3,
+                text: "행사 참여자 대상 설문조사 '매우 만족' 응답 비율 63.7% 확보",
+            },
+        ],
+    })
+    keyAchievement: OutputItemDto[];
+
+    @ApiProperty({
+        type: OutputItemDto,
+        isArray: true,
+        example: [
+            {
+                type: 'line',
+                number: 1,
+                text: "예상치 못한 변수에 대응하기 위해 '플랜 B'를 사전에 준비하는 시스템을 구축하고, 인원 변동 등 리스크를 미리 시뮬레이션하며 위기관리 능력을 길렀다.",
+            },
+            {
+                type: 'line',
+                number: 2,
+                text: "성공적인 기획은 정교한 콘텐츠뿐만 아니라, 참여자 간의 관계와 현장의 분위기, 즉 '관계의 리듬'을 설계하는 것에서 비롯된다는 점을 깨달았다.",
+            },
+            {
+                type: 'line',
+                number: 3,
+                text: "동아리 활동 경험을 바탕으로, 앞으로 어떤 조직에서든 구성원의 장점을 살리고 편안한 협업 분위기를 조성하는 '사람 중심'의 운영 방식을 적용해 나가겠다.",
+            },
+        ],
+    })
+    insight: OutputItemDto[];
+
+    static from(dto: any): MasterPortfolioOutputDto {
+        const output = new MasterPortfolioOutputDto();
+        output.detailInfo = dto.detailInfo;
+        output.assignedTask = dto.assignedTask;
+        output.keyAchievement = dto.keyAchievement;
+        output.insight = dto.insight;
+        return output;
+    }
+}

--- a/src/modules/portfolio-corrections/portfolio-corrections.controller.ts
+++ b/src/modules/portfolio-corrections/portfolio-corrections.controller.ts
@@ -28,6 +28,7 @@ import { CorrectionResultDto, GetCorrectionResultDto } from './dtos/correction-r
 import { StatusResponseDto } from './dtos/status-response.dto';
 import { ApiCommonErrorResponses } from 'src/common/decorators/api-common-error-responses.decorator';
 import { UpdatePortfolioCorrectionDto } from './dtos/portfolio-correction.dto';
+import { MasterPortfolioOutputDto } from './dtos/master-portfolio-output.dto';
 
 @ApiTags('PortfolioCorrections')
 @Controller('portfolio-corrections')
@@ -271,9 +272,27 @@ export class PortfolioCorrectionsController {
         return await this.portfolioCorrectionsService.getCorrection(correctionId);
     }
 
+    @ApiOperation({
+        summary: '(4-2) AI 첨삭 대상 마스터 포트폴리오 조회',
+        description: 'AI 첨삭의 특정 마스터 포트폴리오 정보를 조회합니다.',
+    })
+    @ApiParam({ name: 'projectId', type: Number, description: '프로젝트 ID' })
+    @ApiCommonResponse(MasterPortfolioOutputDto)
+    @ApiCommonErrorResponses(HttpStatus.NOT_FOUND, {
+        errorCode: 'MASTERPORTFOLIO4041',
+        reason: '마스터 포트폴리오를 찾을 수 없습니다.',
+    })
+    @Get(':projectId/master-portfolios')
+    async getMasterPortfolio(
+        @User('id') userId: number,
+        @Param('projectId', ParseIntPipe) projectId: number
+    ) {
+        return await this.portfolioCorrectionsService.getMasterPortfolio(userId, projectId);
+    }
+
     // 결과 개별 조회 API
     @ApiOperation({
-        summary: '(4-2) AI 첨삭 결과 개별 조회',
+        summary: '(4-3) AI 첨삭 결과 개별 조회',
         description: '특정 AI 첨삭의 결과를 개별적으로 조회합니다.',
     })
     @ApiParam({ name: 'correctionId', type: Number, description: '포트폴리오 첨삭 ID' })

--- a/src/modules/portfolio-corrections/portfolio-corrections.module.ts
+++ b/src/modules/portfolio-corrections/portfolio-corrections.module.ts
@@ -9,6 +9,7 @@ import { AICorrection } from './entities/ai-correction.entity';
 import { Project } from '../projects/entities/projects.entity';
 import { RAGData } from './entities/rag-data.entity';
 import { MasterPortfolioAI } from '../master-portfolios/entities/master-portfolio-ai.entity';
+import { MasterPortfolio } from '../master-portfolios/entities/master-portfolios.entity';
 
 @Module({
     imports: [
@@ -18,6 +19,7 @@ import { MasterPortfolioAI } from '../master-portfolios/entities/master-portfoli
             Project,
             RAGData,
             MasterPortfolioAI,
+            MasterPortfolio,
         ]),
         LLMModule,
     ],

--- a/src/modules/portfolio-corrections/services/portfolio-corrections.service.ts
+++ b/src/modules/portfolio-corrections/services/portfolio-corrections.service.ts
@@ -12,6 +12,7 @@ import {
     AIGenerationAlreadyExists,
     LLMZodErrorException,
     MasterPortfolioAINotFoundException,
+    MasterPortfolioNotFoundException,
     PortfolioCorrectionNotFoundException,
     ProjectMaxSelectedException,
     ProjectNotFoundException,
@@ -32,6 +33,9 @@ import { StatusResponseDto } from '../dtos/status-response.dto';
 import { ResponseDelayManager } from 'src/common/utils/response-delay.util';
 import { CorrectionResultDto, GetCorrectionResultDto } from '../dtos/correction-result.dto';
 import { UpdatePortfolioCorrectionDto } from '../dtos/portfolio-correction.dto';
+import { MasterPortfolio } from 'src/modules/master-portfolios/entities/master-portfolios.entity';
+import { TransformMasterPortfolioUtil } from 'src/common/utils/transformMasterPortfolio.util';
+import { MasterPortfolioOutputDto } from '../dtos/master-portfolio-output.dto';
 
 async function checkCorrectionExists(qr: QueryRunner, correctionId: number) {
     // correctionId에 해당하는 포트폴리오 첨삭 엔티티가 있는지
@@ -57,7 +61,9 @@ export class PortfolioCorrectionsService {
         @InjectRepository(RAGData)
         private readonly ragDataRepository: Repository<RAGData>,
         @InjectRepository(MasterPortfolioAI)
-        private readonly masterPortfolioAIRepository: Repository<MasterPortfolioAI>
+        private readonly masterPortfolioAIRepository: Repository<MasterPortfolioAI>,
+        @InjectRepository(MasterPortfolio)
+        private readonly masterPortfolioRepository: Repository<MasterPortfolio>
     ) {}
     async getPortfolioCorrectionsByUser(userId: number, cursorDate: Date, pageSize: number) {
         const portfolios = await this.correctionRepository
@@ -449,5 +455,24 @@ export class PortfolioCorrectionsService {
             throw new PortfolioCorrectionNotFoundException(correctionId);
         }
         return `포트폴리오 첨삭 id ${correctionId}가 성공적으로 삭제되었습니다.`;
+    }
+
+    // AI 첨삭 페이지에서 projectId로 마스터 포트폴리오 개별 조회
+    async getMasterPortfolio(userId: number, projectId: number) {
+        const masterPortfolio = await this.masterPortfolioRepository.findOne({
+            where: { user: { id: userId }, project: { id: projectId } },
+        });
+        if (!masterPortfolio) {
+            throw new MasterPortfolioNotFoundException(`프로젝트 ID: ${projectId}`);
+        }
+        const input = {
+            detailInfo: masterPortfolio.detailInfo || '',
+            assignedTask: masterPortfolio.assignedTask || '',
+            keyAchievement: masterPortfolio.keyAchievement || '',
+            insight: masterPortfolio.insight || '',
+        };
+
+        const result = TransformMasterPortfolioUtil.transformMasterPortfolio(input);
+        return MasterPortfolioOutputDto.from(result);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #359 

## ✅ 작업 내용

- AI 첨삭 대상 마스터 포트폴리오 조회 API 구현
- transformMasterPortfolio 유틸리티 함수 추가
- MasterPortfolioOutputDto 추가
- input, output portfolio interface 추가

## 📸 스크린샷

- 왼쪽 데이터 (DB에서 조회) -> 오른쪽 형태로 변환
<img width="1155" height="522" alt="image" src="https://github.com/user-attachments/assets/67b58023-eaaa-46c6-b1eb-d927a2e1ec5c" />
<img width="600" height="818" alt="image" src="https://github.com/user-attachments/assets/726bf085-f2b6-4ef6-9c73-73933a69cb4e" />

## 📎 기타 참고사항
