### PR TITLE
[Feat] 나의 업무 더보기 API 구현

### DIFF
--- a/src/config/swagger-examples.ts
+++ b/src/config/swagger-examples.ts
@@ -12,6 +12,7 @@ export const hasNextPageExampleOfMyTasks = {
                         name: '1차 과제 제출용 와이어프레임',
                         status: 'ONGOING',
                         deadline: '2025-08-15T10:00:00Z',
+                        createdAt: '2025-08-03T19:50:31.920Z',
                         managers: [
                             {
                                 userId: 123,
@@ -115,6 +116,159 @@ export const lastPageExampleOfMyCorrections = {
         pageInfo: {
             nextCursor: null,
             hasNextPage: false,
+        },
+    },
+};
+
+export const hasNextPageExampleOfMyTasksMore = {
+    isSuccess: true,
+    error: null,
+    result: {
+        data: [
+            {
+                id: 12,
+                name: '9월 정기모임 운영 공지',
+                status: 'ONGOING',
+                deadline: '2025-09-01T14:59:59.000Z',
+                createdAt: '2025-08-21T19:50:31.849Z',
+                managers: [
+                    {
+                        userId: 123,
+                        name: '홍길동',
+                        imageUrl: 'https://s3:example.com/profile/example.png',
+                    },
+                ],
+            },
+            {
+                id: 15,
+                name: '가을행사 운영기획안 작성',
+                status: 'ONGOING',
+                deadline: '2025-09-13T14:59:59.000Z',
+                createdAt: '2025-08-21T19:50:31.867Z',
+                managers: [
+                    {
+                        userId: 123,
+                        name: '홍길동',
+                        imageUrl: 'https://s3:example.com/profile/example.png',
+                    },
+                ],
+            },
+            {
+                id: 13,
+                name: '9월 정기모임 회계 처리',
+                status: 'NOTSTART',
+                deadline: '2025-09-20T14:59:59.000Z',
+                createdAt: '2025-08-21T19:50:31.854Z',
+                managers: [
+                    {
+                        userId: 123,
+                        name: '홍길동',
+                        imageUrl: 'https://s3:example.com/profile/example.png',
+                    },
+                ],
+            },
+            {
+                id: 14,
+                name: '9월 정기모임 피드백 정리',
+                status: 'NOTSTART',
+                deadline: '2025-09-20T14:59:59.000Z',
+                createdAt: '2025-08-21T19:50:31.860Z',
+                managers: [
+                    {
+                        userId: 123,
+                        name: '홍길동',
+                        imageUrl: 'https://s3:example.com/profile/example.png',
+                    },
+                ],
+            },
+            {
+                id: 16,
+                name: '가을행사 운영 공지',
+                status: 'NOTSTART',
+                deadline: '2025-09-28T14:59:59.000Z',
+                createdAt: '2025-08-21T19:50:31.872Z',
+                managers: [
+                    {
+                        userId: 123,
+                        name: '홍길동',
+                        imageUrl: 'https://s3:example.com/profile/example.png',
+                    },
+                ],
+            },
+        ],
+        pageInfo: {
+            nextCursor:
+                'eyJkZWFkbGluZSI6IjIwMjUtMDktMjhUMTQ6NTk6NTkuMDAwWiIsImNyZWF0ZWRBdCI6IjIwMjUtMDgtMjFUMTk6NTA6MzEuODcyWiJ9',
+            hasNextPage: true,
+        },
+    },
+};
+
+export const lastPageExampleOfMyTasksMore = {
+    isSuccess: true,
+    error: null,
+    result: {
+        data: [
+            {
+                id: 25,
+                name: '12월 정기모임 운영 공지',
+                status: 'NOTSTART',
+                deadline: '2025-12-01T14:59:59.000Z',
+                createdAt: '2025-08-21T19:50:31.920Z',
+                managers: [
+                    {
+                        userId: 123,
+                        name: '홍길동',
+                        imageUrl: 'https://s3:example.com/profile/example.png',
+                    },
+                ],
+            },
+            {
+                id: 26,
+                name: '12월 정기모임 회계 처리',
+                status: 'NOTSTART',
+                deadline: '2025-12-26T14:59:59.000Z',
+                createdAt: '2025-08-21T19:50:31.926Z',
+                managers: [
+                    {
+                        userId: 123,
+                        name: '홍길동',
+                        imageUrl: 'https://s3:example.com/profile/example.png',
+                    },
+                ],
+            },
+            {
+                id: 27,
+                name: '12월 정기모임 피드백 정리',
+                status: 'NOTSTART',
+                deadline: '2025-12-29T14:59:59.000Z',
+                createdAt: '2025-08-21T19:50:31.933Z',
+                managers: [
+                    {
+                        userId: 123,
+                        name: '홍길동',
+                        imageUrl: 'https://s3:example.com/profile/example.png',
+                    },
+                ],
+            },
+            {
+                id: 9,
+                name: '기획국 하반기 결산보고안 작성',
+                status: 'ONGOING',
+                deadline: '2026-01-07T14:59:59.000Z',
+                createdAt: '2025-08-21T19:50:31.819Z',
+                managers: [
+                    {
+                        userId: 123,
+                        name: '홍길동',
+                        imageUrl: 'https://s3:example.com/profile/example.png',
+                    },
+                ],
+            },
+        ],
+        pageInfo: {
+            nextCursor: '2025-08-15T00:00:00Z',
+            hasNextPage: true,
         },
     },
 };

--- a/src/modules/tasks/dtos/user-task.dto.ts
+++ b/src/modules/tasks/dtos/user-task.dto.ts
@@ -29,6 +29,12 @@ export class TaskCardDTO {
     deadline?: string;
 
     @ApiProperty({
+        example: '2025-08-13T10:00:00Z',
+        description: '업무의 생성일',
+    })
+    createdAt: string;
+
+    @ApiProperty({
         description: '업무의 담당자 리스트',
         isArray: true,
         type: UserProfile,
@@ -40,6 +46,7 @@ export class TaskCardDTO {
         name: string;
         status: Status;
         deadline: Date | null;
+        createdAt: Date;
         managers: Manager[];
     }) {
         const dto = new TaskCardDTO();
@@ -47,6 +54,7 @@ export class TaskCardDTO {
         dto.name = entity.name;
         dto.status = entity.status;
         if (entity.deadline) dto.deadline = entity.deadline.toISOString();
+        dto.createdAt = entity.createdAt.toISOString();
         dto.managers = entity.managers.map((manager) => UserProfile.from(manager.user));
         return dto;
     }

--- a/src/modules/tasks/repositories/task.repository.ts
+++ b/src/modules/tasks/repositories/task.repository.ts
@@ -222,9 +222,10 @@ export class TaskRepository {
         projectId: number,
         userId: number,
         statuses: Status[],
-        maxCardNum: number
+        maxCardNum: number,
+        cursor?: { deadline: string; createdAt: string }
     ): Promise<{ id: number }[]> {
-        return this.repo
+        const qb = this.repo
             .createQueryBuilder('task')
             .leftJoin('task.step', 'step')
             .where('step.projectId = :projectId', { projectId })
@@ -239,12 +240,21 @@ export class TaskRepository {
                     .getQuery();
                 return `EXISTS ${sub}`;
             })
-            .orderBy('task.deadline IS NULL', 'ASC') // NULLS LAST
-            .addOrderBy('task.deadline', 'ASC')
-            .addOrderBy('task.createdAt', 'ASC')
-            .limit(maxCardNum)
-            .select('task.id', 'id')
-            .getRawMany();
+            .orderBy("IFNULL(task.deadline, '9999-12-31')", 'ASC') // NULLS LAST
+            .addOrderBy('task.createdAt', 'ASC');
+
+        // 커서가 있는 경우 복합 조건 추가
+        if (cursor) {
+            qb.andWhere(
+                `(IFNULL(task.deadline, '9999-12-31'), task.createdAt) > (:deadline, :createdAt)`,
+                {
+                    deadline: cursor.deadline ?? '999-12-31',
+                    createdAt: cursor.createdAt,
+                }
+            );
+        }
+
+        return await qb.limit(maxCardNum).select('task.id', 'id').getRawMany();
     }
 
     //주어진 ID들의 task 상세 정보 배열 반환

--- a/src/modules/tasks/services/tasks.service.ts
+++ b/src/modules/tasks/services/tasks.service.ts
@@ -29,7 +29,6 @@ import { ProjectDashBoardDTO, TaskCardDTO } from '../dtos/user-task.dto';
 import { ConfigService } from '@nestjs/config';
 import { PaginatedResponseDto } from 'src/common/response/paginated-response.dto';
 import { GetSearchTaskDto } from '../dtos/get-search-task.dto';
-import { Brackets } from 'typeorm';
 import { TaskRepository } from '../repositories/task.repository';
 import { ProjectsService } from '../../projects/services/projects.service';
 import { StepRepository } from '../../steps/repositories/step.repository';
@@ -567,13 +566,22 @@ export class TasksService {
         projectId: number,
         cursor?: string
     ): Promise<PaginatedResponseDto<TaskCardDTO>> {
+        // 0. 쿼리 파라미터 유효성 검사
+        //NOTE: 수정 필요
+        await this.projectsService.findByIdWithTasks(projectId);
+
         // 1. 커서의 역직렬화
-        const decodedCursor = cursor
-            ? (JSON.parse(Buffer.from(cursor, 'base64').toString()) as {
-                  deadline: string;
-                  createdAt: string;
-              })
-            : undefined;
+        let decodedCursor: any;
+        try {
+            decodedCursor = cursor
+                ? (JSON.parse(Buffer.from(cursor, 'base64').toString()) as {
+                      deadline: string;
+                      createdAt: string;
+                  })
+                : undefined;
+        } catch (e) {
+            throw new BadRequestException('커서가 유효하지 않습니다.');
+        }
         // 2. 업무 조회 및 DTO로 변환하여 반환
         const tasks = await this.getTaskByProject(userId, projectId, decodedCursor);
 

--- a/src/modules/tasks/services/tasks.service.ts
+++ b/src/modules/tasks/services/tasks.service.ts
@@ -561,20 +561,65 @@ export class TasksService {
         return PaginatedResponseDto.of(results, nextCursor, hasNextPage);
     }
 
+    // 사용자 별 나의 업무 조회 더보기 - 프로젝트 기준
+    async getTasksMoreByUser(
+        userId: number,
+        projectId: number,
+        cursor?: string
+    ): Promise<PaginatedResponseDto<TaskCardDTO>> {
+        // 1. 커서의 역직렬화
+        const decodedCursor = cursor
+            ? (JSON.parse(Buffer.from(cursor, 'base64').toString()) as {
+                  deadline: string;
+                  createdAt: string;
+              })
+            : undefined;
+        // 2. 업무 조회 및 DTO로 변환하여 반환
+        const tasks = await this.getTaskByProject(userId, projectId, decodedCursor);
+
+        // 3. hasNextPage 판단
+        let hasNextPage: boolean = false;
+        const maxCardNum: number = Number(this.configService.get('MAX_TASK_PAGE')) || 5;
+        const next = await this.taskRepository.findTaskIdsForUserAssignedOngoingTasks(
+            projectId,
+            userId,
+            [Status.ONGOING, Status.NOTSTART],
+            maxCardNum + 1,
+            decodedCursor
+        );
+        if (next.length > maxCardNum) {
+            hasNextPage = true;
+        }
+
+        // 4. nextCursor 계산
+        let nextCursor: string | null = null;
+        if (hasNextPage) {
+            const lastTask = tasks[tasks.length - 1];
+            const cursorObj = {
+                deadline: lastTask.deadline ?? null,
+                createdAt: lastTask.createdAt,
+            };
+            nextCursor = Buffer.from(JSON.stringify(cursorObj)).toString('base64');
+        }
+        return PaginatedResponseDto.of(tasks, nextCursor, hasNextPage);
+    }
+
     // 프로젝트 별 나의 업무 조회
     async getTaskByProject(
         userId: number,
         projectId: number,
-        cursor?: any
+        cursor?: { deadline: string; createdAt: string }
     ): Promise<TaskCardDTO[]> {
         const maxCardNum: number = Number(this.configService.get('MAX_TASK_PAGE')) || 5;
+        const decodedCursor = cursor ? cursor : undefined;
 
         // 1. 조건에 맞는 task id만 선조회
         const idRows = await this.taskRepository.findTaskIdsForUserAssignedOngoingTasks(
             projectId,
             userId,
             [Status.ONGOING, Status.NOTSTART],
-            maxCardNum
+            maxCardNum,
+            decodedCursor
         );
 
         const ids = idRows.map((r) => r.id);

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -132,6 +132,11 @@ export class UsersController {
         description:
             '홈 > 나의 업무 페이지의 업무 대시보드를 프로젝트 기준으로 필터링하여 업무를 추가 조회하는 API입니다. 커서는 1) 업무의 마감일, 2) 업무의 생성일을 기준으로 하는 복합커서입니다. 커서가 없는 경우 초기 더보기로 조회되는 업무 이후의 maxCardNum만큼의 업무를 조회합니다.',
     })
+    @ApiCommonResponseWithPagination(
+        TaskCardDTO,
+        hasNextPageExampleOfMyTasksMore,
+        lastPageExampleOfMyTasksMore
+    )
     @ApiQuery({ name: 'projectId', type: Number, required: true })
     @ApiQuery({ name: 'cursor', type: String, required: false })
     @Get('/me/tasks/more')

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -130,7 +130,7 @@ export class UsersController {
     @ApiOperation({
         summary: '나의 업무 조회/더보기',
         description:
-            '홈 > 나의 업무 페이지의 업무 대시보드를 프로젝트 기준으로 필터링하여 업무를 추가 조회하는 API입니다. 커서는 1) 업무의 마감일, 2) 업무의 생성일을 기준으로 하는 복합커서입니다. 커서가 없는 경우 초기 더보기로 조회되는 업무 이후의 maxCardNum만큼의 업무를 조회합니다.',
+            '홈 > 나의 업무 페이지의 업무 대시보드에서 더보기를 눌렀을 때, 프로젝트 기준으로 필터링하여 업무를 추가 조회하는 API입니다. 커서는 1) 업무의 마감일, 2) 업무의 생성일을 기준으로 하는 복합커서입니다. 커서가 없는 경우 맨 처음 maxCardNum만큼의 업무를 조회합니다.',
     })
     @ApiCommonResponseWithPagination(
         TaskCardDTO,

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -13,7 +13,7 @@ import {
     UsePipes,
     ValidationPipe,
 } from '@nestjs/common';
-import { ApiBody, ApiConsumes, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiConsumes, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { User } from 'src/common/decorators/user.decorator';
 import { UsersService } from './services/users.service';
 import {
@@ -31,7 +31,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { UserMainTaskRequestDTO } from './dtos/user-main-task.dto';
 import { UserMasterPortfoliosResponseDto } from '../master-portfolios/dtos/user-master-portfolios-response.dto';
 import { UserProjectResponseDto } from './dtos/user-project.dto';
-import { ProjectDashBoardDTO } from '../tasks/dtos/user-task.dto';
+import { ProjectDashBoardDTO, TaskCardDTO } from '../tasks/dtos/user-task.dto';
 import { DateCursor } from 'src/common/dtos/date-cursor.dto';
 import { PaginatedResponseDto } from 'src/common/response/paginated-response.dto';
 import { TasksService } from '../tasks/services/tasks.service';
@@ -40,9 +40,11 @@ import {
     hasNextPageExampleOfMyCorrections,
     hasNextPageExampleOfMyPortfolios,
     hasNextPageExampleOfMyTasks,
+    hasNextPageExampleOfMyTasksMore,
     lastPageExampleOfMyCorrections,
     lastPageExampleOfMyPortfolios,
     lastPageExampleOfMyTasks,
+    lastPageExampleOfMyTasksMore,
 } from 'src/config/swagger-examples';
 import { ConfigService } from '@nestjs/config';
 import { MasterPortfoliosService } from '../master-portfolios/services/master-portfolios.service';
@@ -123,6 +125,22 @@ export class UsersController {
         @Query(new ValidationPipe({ transform: true })) query?: DateCursor
     ): Promise<PaginatedResponseDto<ProjectDashBoardDTO>> {
         return await this.tasksService.getTaskByUser(userId, query?.cursor);
+    }
+
+    @ApiOperation({
+        summary: '나의 업무 조회/더보기',
+        description:
+            '홈 > 나의 업무 페이지의 업무 대시보드를 프로젝트 기준으로 필터링하여 업무를 추가 조회하는 API입니다. 커서는 1) 업무의 마감일, 2) 업무의 생성일을 기준으로 하는 복합커서입니다. 커서가 없는 경우 초기 더보기로 조회되는 업무 이후의 maxCardNum만큼의 업무를 조회합니다.',
+    })
+    @ApiQuery({ name: 'projectId', type: Number, required: true })
+    @ApiQuery({ name: 'cursor', type: String, required: false })
+    @Get('/me/tasks/more')
+    async getMoreUserTasksPerProject(
+        @User('id') userId: number,
+        @Query('projectId', ParseIntPipe) projectId: number,
+        @Query('cursor') cursor?: string
+    ): Promise<PaginatedResponseDto<TaskCardDTO>> {
+        return await this.tasksService.getTasksMoreByUser(userId, projectId, cursor);
     }
 
     @ApiOperation({


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #200 

## ✅ 작업 내용

- 업무의 마감일 및 생성일을 복합 커서로 하는 나의 업무 추가 조회 기능 구현
- 커서가 없을 때는 처음 5개의 업무를 조회함.

## 📸 스크린샷
**[테스트 데이터]**
<img width="714" height="520" alt="image" src="https://github.com/user-attachments/assets/97809e87-ebac-47c9-82b0-cee55b433177" />

**[PROJECT_NOT_FOUND]**
<img width="877" height="456" alt="image" src="https://github.com/user-attachments/assets/4d3c7fa7-a48e-4eae-8563-9ec79d67f941" />

**[BAD_REQUEST/유효하지 않은 커서값]**
<img width="884" height="458" alt="image" src="https://github.com/user-attachments/assets/7a14ab2b-5d92-4fa3-b8b2-e83a12338ef2" />

**[조회/200]**
<img width="885" height="685" alt="image" src="https://github.com/user-attachments/assets/5b003687-d42a-439c-81c9-30fd254fc389" />
<img width="877" height="722" alt="image" src="https://github.com/user-attachments/assets/e2284425-7115-46a0-ae9e-f3e434ef002e" />
<img width="879" height="709" alt="image" src="https://github.com/user-attachments/assets/438c6984-424f-40dc-bf49-d71bd22a61b6" />

## 📎 기타 참고사항

- 기존 나의 업무 조회 API에 대해서도 업무에 대한 커서를 포함하도록 응답 수정 및 서비스 로직의 효율성을 체크해 볼 필요가 있음. 추후 다른 이슈로 처리 예정.
- 커서값에 대한 유효성 체크 로직을 추가로 붙일 필요 있음.
- 현재 커서로 반환하는 값이 100자 정도의 다소 긴 값이라 더 나은 방법이 있는지 찾아볼 예정입니다~