### PR TITLE
[Refactor] 사용자의 프로젝트 권한 체크 로직용 커스텀 가드를 추가 및 기존 API에 적용

### DIFF
--- a/src/modules/plans/guards/plan-member.guard.ts
+++ b/src/modules/plans/guards/plan-member.guard.ts
@@ -1,0 +1,20 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { ProjectsService } from 'src/modules/projects/services/projects.service';
+import { PlanRepository } from '../repositories/plan.repository';
+
+@Injectable()
+export class PlanMemberGuard implements CanActivate {
+    constructor(
+        private readonly projectService: ProjectsService,
+        private readonly planRepository: PlanRepository
+    ) {}
+
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+        const request = context.switchToHttp().getRequest();
+        const userId = request.user?.id;
+        const planId = Number(request.params.planId);
+        const plan = await this.planRepository.findByIdWithProjectId(planId);
+        const projectId = plan.project.id;
+        return await this.projectService.assertProjectMember(userId, projectId);
+    }
+}

--- a/src/modules/plans/plans.controller.ts
+++ b/src/modules/plans/plans.controller.ts
@@ -8,6 +8,7 @@ import {
     ParseIntPipe,
     Patch,
     Req,
+    UseGuards,
 } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { User } from 'src/common/decorators/user.decorator';
@@ -17,12 +18,12 @@ import {
 } from 'src/common/response/swagger-response.helper';
 import { PlanDetails } from './dtos/plan-details.dto';
 import { PlansService } from './services/plans.service';
-import { ProjectForbiddenException } from 'src/common/exceptions/custom.errors';
 import { Transactional, TransactionalRequest } from 'src/common/decorators/transaction.decorator';
 import { DeletePlanResponseDto } from './dtos/delete-plan.dto';
 import { BasicUpdatePlanReqDTO, UpdatePlanUserReqDTO } from './dtos/update-plan.dto';
 import { ErrorCode } from 'src/common/exceptions/errorcode.enum';
 import { ApiCommonErrorResponses } from 'src/common/decorators/api-common-error-responses.decorator';
+import { PlanMemberGuard } from './guards/plan-member.guard';
 
 @ApiTags('Plans')
 @Controller('/plans')
@@ -39,13 +40,9 @@ export class PlansController {
         'PLAN을 찾을 수 없습니다.',
         HttpStatus.NOT_FOUND
     )
+    @UseGuards(PlanMemberGuard)
     @Get('/:planId')
-    async getDetails(
-        @User('id') userId: number,
-        @Param('planId', ParseIntPipe) planId: number
-    ): Promise<PlanDetails> {
-        const check = await this.plansService.checkPermission(userId, planId);
-        if (!check) throw new ProjectForbiddenException();
+    async getDetails(@Param('planId', ParseIntPipe) planId: number): Promise<PlanDetails> {
         return this.plansService.getDetails(planId);
     }
 
@@ -64,6 +61,7 @@ export class PlansController {
         '해당 프로젝트에 접근 권한이 없습니다.',
         HttpStatus.FORBIDDEN
     )
+    @UseGuards(PlanMemberGuard)
     @Transactional()
     @Delete('/:planId')
     async deletePlan(
@@ -90,15 +88,15 @@ export class PlansController {
         '해당 프로젝트에 접근 권한이 없습니다.',
         HttpStatus.FORBIDDEN
     )
+    @UseGuards(PlanMemberGuard)
     @Transactional()
     @Patch('/:planId')
     async updatePlan(
         @Req() req: TransactionalRequest,
-        @User('id') userId: number,
         @Param('planId', ParseIntPipe) planId: number,
         @Body() body: BasicUpdatePlanReqDTO
     ): Promise<PlanDetails> {
-        return await this.plansService.updatePlan(req.queryRunner, userId, planId, body);
+        return await this.plansService.updatePlan(req.queryRunner, planId, body);
     }
 
     @ApiOperation({
@@ -128,6 +126,7 @@ export class PlansController {
             data: '프로젝트에 참여하지 않은 사용자 ID가 포함되어 있습니다.',
         },
     ])
+    @UseGuards(PlanMemberGuard)
     @Transactional()
     @Patch('/:planId/members')
     async updatePlanUserList(

--- a/src/modules/plans/services/plans.service.ts
+++ b/src/modules/plans/services/plans.service.ts
@@ -4,7 +4,6 @@ import { PlanDetails } from '../dtos/plan-details.dto';
 import {
     PlanDateConflictException,
     PlanTransactionException,
-    ProjectForbiddenException,
     TransactionException,
 } from 'src/common/exceptions/custom.errors';
 import { ProjectsService } from '../../projects/services/projects.service';
@@ -133,13 +132,6 @@ export class PlansService {
         return PlanDetails.from(await this.planRepository.findByIdWithDetail(planId));
     }
 
-    // NOTE: 사용자의 권한 체크, Custom Guard로 추후 리팩토링 예정
-    async checkPermission(userId: number, planId: number): Promise<Boolean> {
-        const plan = await this.planRepository.findByIdWithProjectId(planId);
-        const projectId = plan.project.id;
-        return await this.projectsService.assertProjectMember(userId, projectId);
-    }
-
     // 일정 생성
     async createPlan(qr: QueryRunner, projectId: number, date: Date): Promise<CreatePlanResponse> {
         // 유효한 식별자인지 & 사용자 권한 check
@@ -174,16 +166,13 @@ export class PlansService {
     // 일정 수정
     async updatePlan(
         qr: QueryRunner,
-        userId: number,
         planId: number,
         body: BasicUpdatePlanReqDTO
     ): Promise<PlanDetails> {
         // 1. planId에 해당하는 plan의 존재 여부 확인
         const plan = await this.planRepository.findByIdUsingQR(qr, planId);
 
-        // 2. 수정 권한 체크
-        await this.projectsService.isProjectMember(userId, plan.project.id, qr.manager);
-        // 3. 일정 수정
+        // 2. 일정 수정
         try {
             await this.planRepository.updateWithBasicDTO(qr, planId, body);
             const updatedPlan = PlanDetails.from(
@@ -213,17 +202,7 @@ export class PlansService {
         // 1. planId에 해당하는 plan의 존재 여부 확인
         const plan = await this.planRepository.findByIdUsingQR(qr, planId);
 
-        // 2. 프로젝트 권한 체크: 기본 수정 권한
-        const checkUserIsMember = await this.projectsService.isProjectMember(
-            userId,
-            plan.project.id,
-            qr.manager
-        );
-        if (!checkUserIsMember) {
-            throw new ProjectForbiddenException();
-        }
-
-        // 3. req의 유효성 체크
+        // 2. req의 유효성 체크
         if (Array.isArray(body.writers))
             await this.usersService.checkIsUserExistByArray(body.writers, plan.project.id);
         if (Array.isArray(body.attendees))
@@ -231,21 +210,21 @@ export class PlansService {
 
         try {
             const planDetail = await this.planRepository.findByIdWithDetailUsingQR(qr, planId);
-            // 4. 참여자 수정
+            // 3. 참여자 수정
             if (Array.isArray(body.writers)) {
                 const oldSet = new Set(planDetail.writers.map((w) => w.user.id));
                 const newSet = new Set(body.writers || []);
                 const writers = await this.updateWriters(qr, planId, oldSet, newSet);
                 planDetail.writers = writers;
             }
-            // 5. 기록자 수정
+            // 4. 기록자 수정
             if (Array.isArray(body.attendees)) {
                 const oldSet = new Set(planDetail.attendees.map((a) => a.user.id));
                 const newSet = new Set(body.attendees || []);
                 const attendees = await this.updateAttendees(qr, planId, oldSet, newSet);
                 planDetail.attendees = attendees;
             }
-            // 6. 일정 수정
+            // 5. 일정 수정
             await this.planRepository.savePlan(qr, planDetail);
             const updatedPlan = PlanDetails.from(
                 await this.planRepository.findByIdWithDetailUsingQR(qr, planId)
@@ -272,19 +251,9 @@ export class PlansService {
     ): Promise<DeletePlanResponseDto> {
         // 1. planId에 해당하는 plan 조회
         const plan = await this.planRepository.findByIdUsingQR(qr, planId);
-
-        // 2. 사용자의 삭제 권한 검사
         const projectId = plan.project.id;
-        const checkUserIsMember = await this.projectsService.isProjectMember(
-            userId,
-            projectId,
-            qr.manager
-        );
-        if (!checkUserIsMember) {
-            throw new ProjectForbiddenException();
-        }
 
-        // 3. 일정 삭제
+        // 2. 일정 삭제
         await this.planRepository.deletePlan(qr, planId);
         await this.eventBus.publishAsync(
             `${RealTimeEntity.PLAN}.${RealTimeType.DELETED}`,

--- a/src/modules/projects/guards/project-member.guard.ts
+++ b/src/modules/projects/guards/project-member.guard.ts
@@ -8,7 +8,6 @@ export class ProjectMemberGuard implements CanActivate {
     async canActivate(context: ExecutionContext): Promise<boolean> {
         const request = context.switchToHttp().getRequest();
         const userId = request.user?.id;
-        console.log(userId);
         const projectId = Number(request.params.projectId);
         return await this.projectService.assertProjectMember(userId, projectId);
     }

--- a/src/modules/projects/projects.controller.ts
+++ b/src/modules/projects/projects.controller.ts
@@ -37,7 +37,7 @@ import { PlansService } from '../plans/services/plans.service';
 import { TeamCalenderResponseDto } from './dtos/team-calender-response.dto';
 import { CalenderQueryDto } from 'src/common/dtos/calender-date-query.dto';
 import { UserProfile } from '../../common/dtos/user-profile.dto';
-import { ProjectMemberGuard } from '../auth/guards/project-member.guard';
+import { ProjectMemberGuard } from './guards/project-member.guard';
 import { ErrorCode } from 'src/common/exceptions/errorcode.enum';
 import { HttpStatus } from '@nestjs/common';
 import { PermissionResponseDto } from './dtos/get-permission.dto';
@@ -111,12 +111,10 @@ export class ProjectsController {
             reason: '해당 프로젝트에 접근 권한이 없습니다.',
         },
     ])
+    @UseGuards(ProjectMemberGuard)
     @Get('/:projectId')
-    async getProjectFullData(
-        @User('id') userId: number,
-        @Param('projectId', ParseIntPipe) projectId: number
-    ) {
-        return await this.projectsService.getProjectFullData(userId, projectId);
+    async getProjectFullData(@Param('projectId', ParseIntPipe) projectId: number) {
+        return await this.projectsService.getProjectFullData(projectId);
     }
 
     @ApiOperation({ summary: '프로젝트 수정', description: '프로젝트의 정보를 수정합니다.' })
@@ -129,6 +127,7 @@ export class ProjectsController {
             reason: '해당 항목을 수정할 권한이 없습니다.',
         },
     ])
+    @UseGuards(ProjectMemberGuard)
     @Transactional()
     @Patch('/:projectId')
     async updateProject(
@@ -150,6 +149,7 @@ export class ProjectsController {
             reason: '프로젝트는 팀장만 완료할 수 있습니다.',
         },
     ])
+    @UseGuards(ProjectMemberGuard)
     @Transactional()
     @Patch(':projectId/complete')
     async completeProject(
@@ -169,6 +169,7 @@ export class ProjectsController {
     @ApiCommonErrorResponses(HttpStatus.FORBIDDEN, [
         { errorCode: ErrorCode.PROJECT_NOT_FOUND, reason: '프로젝트를 찾을 수 없습니다.' },
     ])
+    @UseGuards(ProjectMemberGuard)
     @Transactional()
     @Post(':projectId/steps')
     async createStep(
@@ -190,6 +191,7 @@ export class ProjectsController {
         { errorCode: ErrorCode.PROJECT_NOT_FOUND, reason: '프로젝트를 찾을 수 없습니다.' },
         { errorCode: ErrorCode.POSTS_EXCEEDED, reason: '포스트잇은 16개까지 생성될 수 있습니다.' },
     ])
+    @UseGuards(ProjectMemberGuard)
     @Post(':projectId/posts')
     async createPost(
         @Req() req: TransactionalRequest,
@@ -216,6 +218,7 @@ export class ProjectsController {
             reason: '해당 프로젝트에 접근 권한이 없습니다.',
         },
     ])
+    @UseGuards(ProjectMemberGuard)
     @Delete(':projectId/posts/:postId')
     async deletePost(
         @User('id') userId: number,
@@ -243,6 +246,7 @@ export class ProjectsController {
         },
         { errorCode: ErrorCode.ALREDY_LEADER, reason: '이미 팀장인 사용자입니다.' },
     ])
+    @UseGuards(ProjectMemberGuard)
     @Transactional()
     @Patch(':projectId/leader')
     async changeProjectLeader(
@@ -269,6 +273,7 @@ export class ProjectsController {
         { errorCode: ErrorCode.NOT_YOUR_PROFILE, reason: '자신의 프로필만 수정할 수 있습니다.' },
         { errorCode: ErrorCode.PROJECT_NOT_FOUND, reason: '프로젝트를 찾을 수 없습니다.' },
     ])
+    @UseGuards(ProjectMemberGuard)
     @Transactional()
     @Patch('/:projectId/profile')
     async changeProfile(
@@ -397,11 +402,13 @@ export class ProjectsController {
         '프로젝트를 찾을 수 없습니다.',
         HttpStatus.NOT_FOUND
     )
+    //NOTE: 추후 커스텀 가드로 프로젝트 종료 여부 체크
+    @UseGuards(ProjectMemberGuard)
     @Get('/:projectId/isCompleted')
     async getProjectIsCompleted(
         @User('id') userId: number,
         @Param('projectId', ParseIntPipe) projectId: number
     ) {
-        return await this.projectsService.isCompleted(userId, projectId);
+        return await this.projectsService.isCompleted(projectId);
     }
 }

--- a/src/modules/projects/services/projects.service.ts
+++ b/src/modules/projects/services/projects.service.ts
@@ -196,13 +196,9 @@ export class ProjectsService {
         return AllProjectResponseDto.fromEntity({ project, posts });
     }
 
-    async getProjectFullData(userId: number, projectId: number): Promise<AllProjectResponseDto> {
+    async getProjectFullData(projectId: number): Promise<AllProjectResponseDto> {
         // 프로젝트 존재 검사
         const project = await this.projectRepository.findByIdWithTask(projectId);
-        // 프로젝트 멤버 권한 검사
-        const check = await this.assertProjectMember(userId, projectId);
-        if (!check) throw new AlreadyProjectCompletedException();
-
         const postsRaw = await this.postsStore.findPosts(projectId, this.postsKeyPrefix);
         const posts = Array.isArray(postsRaw) ? postsRaw.map(PostDto.from) : [];
 
@@ -312,10 +308,6 @@ export class ProjectsService {
         projectId: number,
         userId: number
     ): Promise<CreateStepResponseDto> {
-        // 프로젝트 존재 확인
-        await this.projectRepository.findByProjectIdUsingQR(projectId, qr.manager);
-        // 프로젝트 멤버인지 확인
-        await this.isProjectMember(userId, projectId, qr.manager);
         let savedStep: Step;
         try {
             // 1) 엔티티 생성
@@ -349,14 +341,10 @@ export class ProjectsService {
         userId: number,
         projectId: number
     ): Promise<CreatePostResponseDto> {
-        // 1) 프로젝트 존재 확인, 프로젝트 멤버인지 확인
-        await this.projectRepository.findByIdWithTask(projectId);
-        await this.assertProjectMember(userId, projectId);
-
-        // 2) Redis에서 기존 포스트잇 로드
+        // 1) Redis에서 기존 포스트잇 로드
         const posts = await this.postsStore.findPosts(projectId, this.postsKeyPrefix);
 
-        // 4) 최대 개수 제한
+        // 2) 최대 개수 제한
         if (posts.length >= this.POST_MAX) throw new PostsExceededException();
 
         const newPost = await this.postsStore.savePost(
@@ -365,7 +353,7 @@ export class ProjectsService {
             { userId, content: dto.content },
             this.POST_TTL_SECONDS
         );
-        // 10) 생성된 객체 반환
+        // 3) 생성된 객체 반환
         return CreatePostResponseDto.fromEntity(newPost, projectId);
     }
 
@@ -374,7 +362,6 @@ export class ProjectsService {
         userId: number,
         projectId: number
     ): Promise<DeletePostResponseDto> {
-        await this.assertProjectMember(userId, projectId);
         const res = await this.postsStore.deletePost(
             projectId,
             this.postsKeyPrefix,
@@ -394,8 +381,7 @@ export class ProjectsService {
         dto: ChangeLeaderDto,
         currentUserId: number
     ): Promise<ChangeLeaderResponseDto> {
-        await this.projectRepository.findByProjectIdUsingQR(projectId, qr.manager);
-        await this.isProjectMember(currentUserId, projectId, qr.manager);
+        //NOTE: newId에 대한 유효성 체크 필요 - 유효한 사용자인지
         const { newLeaderId } = dto;
         const newId = newLeaderId;
         const current = await this.userProjectRepository.findProjectLeaderByProjectIdUsingQR(
@@ -437,8 +423,6 @@ export class ProjectsService {
         userId: number,
         dto: UpdateProfileDto
     ): Promise<UpdateProfileResponseDto> {
-        // 프로젝트 완료 여부 검사
-        await this.projectRepository.findByProjectIdUsingQR(projectId, qr.manager);
         // 1. 본인 프로필 수정인지 확인
         if (userId !== dto.id) {
             throw new ProfileForbiddenException();
@@ -596,13 +580,9 @@ export class ProjectsService {
     }
 
     //프로젝트 종료 여부 조회
-    async isCompleted(userId: number, projectId: number): Promise<getProjectIsCompleted> {
-        // 프로젝트 멤버 권한 검사
-        await this.assertProjectMember(userId, projectId);
-
+    async isCompleted(projectId: number): Promise<getProjectIsCompleted> {
         //프로젝트 종료 여부 검사
         const isCompleted = await this.projectRepository.findIsCompletedByProjectId(projectId);
-
         return { isCompleted };
     }
 }

--- a/src/modules/steps/guards/step-member.guard.ts
+++ b/src/modules/steps/guards/step-member.guard.ts
@@ -1,0 +1,20 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { ProjectsService } from 'src/modules/projects/services/projects.service';
+import { StepRepository } from '../repositories/step.repository';
+
+@Injectable()
+export class StepMemberGuard implements CanActivate {
+    constructor(
+        private readonly projectService: ProjectsService,
+        private readonly stepRepository: StepRepository
+    ) {}
+
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+        const request = context.switchToHttp().getRequest();
+        const userId = request.user?.id;
+        const stepId = Number(request.params.stepId);
+        const step = await this.stepRepository.findById(stepId);
+        const projectId = step.project.id;
+        return await this.projectService.assertProjectMember(userId, projectId);
+    }
+}

--- a/src/modules/steps/services/steps.service.ts
+++ b/src/modules/steps/services/steps.service.ts
@@ -30,9 +30,6 @@ export class StepsService {
         dto: UpdateStepDto
     ): Promise<UpdateStepResponseDto> {
         const step = await this.stepRepository.findByIdUsingQR(qr.manager, stepId);
-        if (!step) {
-            throw new StepNotFoundException();
-        }
         step.name = dto.name;
         const updatedStep = await this.stepRepository.saveStep(qr.manager, step);
         await this.eventBus.publishAsync(
@@ -51,12 +48,10 @@ export class StepsService {
         taskId: number
     ): Promise<UpdateTaskStepResponseDto> {
         const { newStepId } = dto;
+
         // 1) task 조회 + 현재 stepId 일치 여부 확인
-
         const step = await this.stepRepository.findByIdWithTask(qr.manager, stepId);
-
-        if (!step) throw new StepNotFoundException();
-
+        // NOTE: 이건 객체에서 인메모리 탐색을 하는 것보다는 쿼리로 만드는게 더 좋을 것 같아요
         const hasTask = step.tasks.some((task) => task.id === taskId);
         if (!hasTask) {
             throw new TaskNotFoundException();

--- a/src/modules/steps/steps.controller.ts
+++ b/src/modules/steps/steps.controller.ts
@@ -1,12 +1,19 @@
-import { Controller, Body, ParseIntPipe, Patch, Delete, Param, Req } from '@nestjs/common';
+import {
+    Controller,
+    Body,
+    ParseIntPipe,
+    Patch,
+    Delete,
+    Param,
+    Req,
+    UseGuards,
+} from '@nestjs/common';
 import { StepsService } from './services/steps.service';
-import { ApiBody, ApiOperation, ApiTags, ApiOkResponse } from '@nestjs/swagger';
+import { ApiOperation, ApiTags, ApiOkResponse } from '@nestjs/swagger';
 import {
     ApiCommonResponse,
     ApiCommonErrorResponse,
 } from '../../common/response/swagger-response.helper';
-import { CreateStepDto } from './dtos/create-step.dto';
-import { User } from 'src/common/decorators/user.decorator';
 import { CommonResponse } from 'src/common/response/common-response.dto';
 import { UpdateStepDto, UpdateStepResponseDto } from './dtos/update-step.dto';
 import { UpdateTaskStepDto, UpdateTaskStepResponseDto } from './dtos/update-task-step.dto';
@@ -14,6 +21,7 @@ import { Transactional } from 'src/common/decorators/transaction.decorator';
 import { TransactionalRequest } from 'src/common/decorators/transaction.decorator';
 import { HttpStatus } from '@nestjs/common';
 import { ErrorCode } from 'src/common/exceptions/errorcode.enum';
+import { StepMemberGuard } from './guards/step-member.guard';
 @ApiTags('Steps')
 @Controller('/steps')
 export class StepsController {
@@ -34,11 +42,11 @@ export class StepsController {
         '인증되지 않은 사용자입니다.',
         HttpStatus.FORBIDDEN
     )
+    @UseGuards(StepMemberGuard)
     @Transactional()
     @Patch('/:stepId')
     async updateStep(
         @Req() req: TransactionalRequest,
-        @User() userId: number,
         @Param('stepId', ParseIntPipe) stepId: number,
         @Body() dto: UpdateStepDto
     ): Promise<UpdateStepResponseDto> {
@@ -70,11 +78,11 @@ export class StepsController {
         '인증되지 않은 사용자입니다.',
         HttpStatus.FORBIDDEN
     )
+    @UseGuards(StepMemberGuard)
     @Transactional()
     @Patch('/:stepId/:taskId')
     async updateTaskStep(
         @Req() req: TransactionalRequest,
-        @User() userId: number,
         @Param('stepId', ParseIntPipe) stepId: number,
         @Param('taskId', ParseIntPipe) taskId: number,
         @Body() dto: UpdateTaskStepDto
@@ -102,11 +110,11 @@ export class StepsController {
         'STEP 내부에 업무가 존재할 경우, 삭제가 불가능합니다',
         HttpStatus.FORBIDDEN
     )
+    @UseGuards(StepMemberGuard)
     @Transactional()
     @Delete('/:stepId')
     async DeleteTaskResponseDto(
         @Req() req: TransactionalRequest,
-        @User() userId: number,
         @Param('stepId', ParseIntPipe) stepId: number
     ): Promise<CommonResponse> {
         return this.stepsService.deleteStep(req.queryRunner, stepId);


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #287 

## ✅ 작업 내용

- ProjectMemberGuard를 projectId를 파라미터로 받는 API에 적용 및 기존 서비스 로직에서 권한 체크용 중복을 제거함
- PlanMemberGuard 추가 및 planId를 파라미터로 받는 API에 적용
- StepMemberGuard 추가 및 stepId를 파라미터로 받는 API에 적용

## 📎 기타 참고사항

- Task 관련해서는 체크해야 할 모듈이 다소 많아서 전체적인 모듈 리팩토링 이후 커스텀 가드 적용하도록 하겠습니다.
- 고친 API가 많지만 바뀐 코드가 많지 않아 스크린샷은 생략하겠습니다. 로컬에서 한 번씩 다 테스트 해 보았으니 혹여나 문제 생기면 말씀해주세요~~
