### PR TITLE
[Fix] 나의 업무 조회 API 응답 수정 및 복합 커서에 대한 처리 추가

### DIFF
--- a/src/common/exceptions/custom.errors.ts
+++ b/src/common/exceptions/custom.errors.ts
@@ -114,6 +114,12 @@ export class ProjectMaxSelectedException extends CustomHttpException {
     }
 }
 
+export class FailToSerializeException extends CustomHttpException {
+    constructor(data?: any) {
+        super(ErrorCode.BAD_REQUEST, `Invalid Cursor Format.`, HttpStatus.BAD_REQUEST, data);
+    }
+}
+
 //401
 export class UnAuthorizedException extends CustomHttpException {
     constructor(data?: any) {

--- a/src/common/utils/serialize-cursor.util.ts
+++ b/src/common/utils/serialize-cursor.util.ts
@@ -1,0 +1,17 @@
+import { FailToSerializeException } from '../exceptions/custom.errors';
+
+export const CursorUtil = {
+    encode<T extends object>(cursorObj: T): string {
+        const jsonString = JSON.stringify(cursorObj);
+        return Buffer.from(jsonString, 'utf-8').toString('base64');
+    },
+
+    decode<T>(cursor: string): T {
+        try {
+            const decodedCursor = Buffer.from(cursor, 'base64').toString('utf-8');
+            return JSON.parse(decodedCursor) as T;
+        } catch (err) {
+            throw new FailToSerializeException();
+        }
+    },
+};

--- a/src/config/swagger-examples.ts
+++ b/src/config/swagger-examples.ts
@@ -22,11 +22,14 @@ export const hasNextPageExampleOfMyTasks = {
                         ],
                     },
                 ],
+                taskCursor:
+                    'eyJkZWFkbGluZSI6IjIwMjUtMDgtMDlUMTU6MDA6MDAuMDAwWiIsImNyZWF0ZWRBdCI6IjIwMjUtMDktMDZUMTA6MTA6MzcuNDEyWiJ9',
             },
             {
                 projectId: 345,
                 projectName: '프로젝트B',
                 tasks: [],
+                taskCursor: null,
             },
         ],
         pageInfo: {
@@ -45,6 +48,7 @@ export const lastPageExampleOfMyTasks = {
                 projectId: 815,
                 projectName: '가장 최근 프로젝트',
                 tasks: [],
+                takCursor: null,
             },
         ],
         pageInfo: {

--- a/src/modules/tasks/dtos/user-task.dto.ts
+++ b/src/modules/tasks/dtos/user-task.dto.ts
@@ -80,11 +80,19 @@ export class ProjectDashBoardDTO {
     })
     tasks: TaskCardDTO[];
 
-    static from(entity: { id: number; name: string; tasks: TaskCardDTO[] }) {
+    @ApiProperty({
+        example:
+            'eyJkZWFkbGluZSI6IjIwMjUtMDktMjhUMTQ6NTk6NTkuMDAwWiIsImNyZWF0ZWRBdCI6IjIwMjUtMDgtMjFUMTk6NTA6MzEuODcyWiJ9",',
+        description: '나의 업무 조회/더보기에 필요한 커서',
+    })
+    taskCursor: string | null;
+
+    static from(entity: { id: number; name: string; tasks: TaskCardDTO[]; cursor: string | null }) {
         const dto = new ProjectDashBoardDTO();
         dto.projectId = entity.id;
         dto.projectName = entity.name;
         dto.tasks = entity.tasks;
+        dto.taskCursor = entity.cursor;
         return dto;
     }
 }

--- a/src/modules/tasks/pipes/cursor-validation.pipe.ts
+++ b/src/modules/tasks/pipes/cursor-validation.pipe.ts
@@ -1,0 +1,43 @@
+import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
+import { plainToInstance, Type } from 'class-transformer';
+import { IsISO8601, IsNotEmpty, IsString, validate } from 'class-validator';
+import { CursorUtil } from 'src/common/utils/serialize-cursor.util';
+
+export class CursorDto {
+    @Type(() => String)
+    @IsISO8601()
+    @IsString()
+    deadline: string;
+
+    @Type(() => String)
+    @IsISO8601()
+    @IsString()
+    @IsNotEmpty()
+    createdAt: string;
+}
+
+@Injectable()
+export class CursorValidationPipe
+    implements PipeTransform<string | undefined, Promise<CursorDto | undefined>>
+{
+    async transform(value: string | undefined): Promise<CursorDto | undefined> {
+        // 커서가 없으면 그대로 통과
+        if (!value) {
+            return undefined;
+        }
+        // 1. Cursor Decode
+        let decoded: object = CursorUtil.decode<CursorDto>(value);
+
+        // 2. DTO 클래스로 변환 및 유효성 검증
+        const cursorObject = plainToInstance(CursorDto, decoded, {
+            enableImplicitConversion: true,
+        });
+        const errors = await validate(cursorObject);
+
+        if (errors.length > 0) {
+            throw new BadRequestException(errors);
+        }
+
+        return cursorObject;
+    }
+}

--- a/src/modules/tasks/repositories/task.repository.ts
+++ b/src/modules/tasks/repositories/task.repository.ts
@@ -248,7 +248,7 @@ export class TaskRepository {
             qb.andWhere(
                 `(IFNULL(task.deadline, '9999-12-31'), task.createdAt) > (:deadline, :createdAt)`,
                 {
-                    deadline: cursor.deadline ?? '999-12-31',
+                    deadline: cursor.deadline ?? '9999-12-31',
                     createdAt: cursor.createdAt,
                 }
             );
@@ -259,12 +259,15 @@ export class TaskRepository {
 
     //주어진 ID들의 task 상세 정보 배열 반환
     async findTasksByIds(ids: number[]): Promise<Task[]> {
-        return this.repo
+        return await this.repo
             .createQueryBuilder('task')
             .leftJoinAndSelect('task.step', 'step')
             .leftJoinAndSelect('task.managers', 'managers')
             .leftJoinAndSelect('managers.user', 'user')
             .whereInIds(ids)
+            .orderBy('task.deadline IS NULL', 'ASC')
+            .addOrderBy('task.deadline', 'ASC')
+            .addOrderBy('task.createdAt', 'ASC')
             .getMany();
     }
 

--- a/src/modules/tasks/services/tasks.service.ts
+++ b/src/modules/tasks/services/tasks.service.ts
@@ -550,10 +550,12 @@ export class TasksService {
         //3. 프로젝트 별 업무 조회
         const results = await Promise.all(
             pagedProjects.map(async (p) => {
+                const { tasks, taskCursor } = await this.getTaskByProject(userId, p.project.id);
                 return ProjectDashBoardDTO.from({
                     id: p.project.id,
                     name: p.project.name,
-                    tasks: await this.getTaskByProject(userId, p.project.id),
+                    tasks: tasks,
+                    cursor: taskCursor,
                 });
             })
         );
@@ -583,33 +585,13 @@ export class TasksService {
             throw new BadRequestException('커서가 유효하지 않습니다.');
         }
         // 2. 업무 조회 및 DTO로 변환하여 반환
-        const tasks = await this.getTaskByProject(userId, projectId, decodedCursor);
+        const { tasks, taskCursor } = await this.getTaskByProject(userId, projectId, decodedCursor);
 
         // 3. hasNextPage 판단
         let hasNextPage: boolean = false;
-        const maxCardNum: number = Number(this.configService.get('MAX_TASK_PAGE')) || 5;
-        const next = await this.taskRepository.findTaskIdsForUserAssignedOngoingTasks(
-            projectId,
-            userId,
-            [Status.ONGOING, Status.NOTSTART],
-            maxCardNum + 1,
-            decodedCursor
-        );
-        if (next.length > maxCardNum) {
-            hasNextPage = true;
-        }
+        if (taskCursor) hasNextPage = true;
 
-        // 4. nextCursor 계산
-        let nextCursor: string | null = null;
-        if (hasNextPage) {
-            const lastTask = tasks[tasks.length - 1];
-            const cursorObj = {
-                deadline: lastTask.deadline ?? null,
-                createdAt: lastTask.createdAt,
-            };
-            nextCursor = Buffer.from(JSON.stringify(cursorObj)).toString('base64');
-        }
-        return PaginatedResponseDto.of(tasks, nextCursor, hasNextPage);
+        return PaginatedResponseDto.of(tasks, taskCursor, hasNextPage);
     }
 
     // 프로젝트 별 나의 업무 조회
@@ -617,31 +599,42 @@ export class TasksService {
         userId: number,
         projectId: number,
         cursor?: { deadline: string; createdAt: string }
-    ): Promise<TaskCardDTO[]> {
+    ): Promise<{
+        tasks: TaskCardDTO[];
+        taskCursor: string | null;
+    }> {
         const maxCardNum: number = Number(this.configService.get('MAX_TASK_PAGE')) || 5;
         const decodedCursor = cursor ? cursor : undefined;
+        let nextCursor: null | string = null;
 
         // 1. 조건에 맞는 task id만 선조회
         const idRows = await this.taskRepository.findTaskIdsForUserAssignedOngoingTasks(
             projectId,
             userId,
             [Status.ONGOING, Status.NOTSTART],
-            maxCardNum,
+            maxCardNum + 1,
             decodedCursor
         );
 
         const ids = idRows.map((r) => r.id);
-        if (ids.length === 0) return [];
+        if (ids.length === 0) return { tasks: [], taskCursor: nextCursor };
 
-        // 2. id들로 상세 로딩 (step, managers, user까지)
-        const tasks = await this.taskRepository.findTasksByIds(ids);
+        // 2. 커서 조직
+        let pageIds = ids;
+        if (idRows.length > maxCardNum) {
+            pageIds = ids.slice(0, maxCardNum);
+            const taskIdOfLast: number = pageIds[maxCardNum - 1];
+            const lastTask = await this.taskRepository.findById(taskIdOfLast);
+            const cursorObj = {
+                deadline: lastTask.deadline ?? null,
+                createdAt: lastTask.createdAt,
+            };
+            nextCursor = Buffer.from(JSON.stringify(cursorObj)).toString('base64');
+        }
 
-        // 3. id 순서대로 정렬
-        const order = new Map(ids.map((id, i) => [id, i]));
-        tasks.sort((a, b) => order.get(a.id)! - order.get(b.id)!);
-
-        // 4. 반환값을 DTO로 변환
-        return tasks.map((task) => TaskCardDTO.from(task));
+        // 3. id들로 상세 로딩 (step, managers, user까지) 및 DTO 변환 및 값 반환
+        const tasks = await this.taskRepository.findTasksByIds(pageIds);
+        return { tasks: tasks.map((task) => TaskCardDTO.from(task)), taskCursor: nextCursor };
     }
 
     async getSearchTask(
@@ -720,7 +713,6 @@ export class TasksService {
                 steps: stepGroups,
                 totalCount,
             };
-            return { projectId, projectName: project.name, steps: stepGroups, totalCount };
         }
     }
     async getSearchMoreTasksByStep(

--- a/src/modules/tasks/services/tasks.service.ts
+++ b/src/modules/tasks/services/tasks.service.ts
@@ -53,6 +53,8 @@ import {
 } from '../dtos/task-payload.dto';
 import { CreatedCommentDTO } from '../../comments/dto/comment-payload.dto';
 import { TaskUpdatedSubType } from '../enums/task-update-type.enum';
+import { CursorUtil } from 'src/common/utils/serialize-cursor.util';
+import { CursorDto } from '../pipes/cursor-validation.pipe';
 @Injectable()
 export class TasksService {
     constructor(
@@ -566,26 +568,13 @@ export class TasksService {
     async getTasksMoreByUser(
         userId: number,
         projectId: number,
-        cursor?: string
+        cursor?: CursorDto
     ): Promise<PaginatedResponseDto<TaskCardDTO>> {
-        // 0. 쿼리 파라미터 유효성 검사
-        //NOTE: 수정 필요
+        // 1. 쿼리 파라미터 유효성 검사 - 커서의 유효성 검사는 파이프로 수행
         await this.projectsService.findByIdWithTasks(projectId);
 
-        // 1. 커서의 역직렬화
-        let decodedCursor: any;
-        try {
-            decodedCursor = cursor
-                ? (JSON.parse(Buffer.from(cursor, 'base64').toString()) as {
-                      deadline: string;
-                      createdAt: string;
-                  })
-                : undefined;
-        } catch (e) {
-            throw new BadRequestException('커서가 유효하지 않습니다.');
-        }
         // 2. 업무 조회 및 DTO로 변환하여 반환
-        const { tasks, taskCursor } = await this.getTaskByProject(userId, projectId, decodedCursor);
+        const { tasks, taskCursor } = await this.getTaskByProject(userId, projectId, cursor);
 
         // 3. hasNextPage 판단
         let hasNextPage: boolean = false;
@@ -598,7 +587,7 @@ export class TasksService {
     async getTaskByProject(
         userId: number,
         projectId: number,
-        cursor?: { deadline: string; createdAt: string }
+        cursor?: CursorDto
     ): Promise<{
         tasks: TaskCardDTO[];
         taskCursor: string | null;
@@ -629,7 +618,7 @@ export class TasksService {
                 deadline: lastTask.deadline ?? null,
                 createdAt: lastTask.createdAt,
             };
-            nextCursor = Buffer.from(JSON.stringify(cursorObj)).toString('base64');
+            nextCursor = CursorUtil.encode(cursorObj);
         }
 
         // 3. id들로 상세 로딩 (step, managers, user까지) 및 DTO 변환 및 값 반환

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -50,6 +50,7 @@ import { ConfigService } from '@nestjs/config';
 import { MasterPortfoliosService } from '../master-portfolios/services/master-portfolios.service';
 import { UserPortfolioCorrectionResponseDto } from '../portfolio-corrections/dtos/user-portfolio-correction-response.dto';
 import { PortfolioCorrectionsService } from '../portfolio-corrections/services/portfolio-corrections.service';
+import { CursorDto, CursorValidationPipe } from '../tasks/pipes/cursor-validation.pipe';
 
 @ApiTags('Users')
 @Controller('users')
@@ -143,7 +144,7 @@ export class UsersController {
     async getMoreUserTasksPerProject(
         @User('id') userId: number,
         @Query('projectId', ParseIntPipe) projectId: number,
-        @Query('cursor') cursor?: string
+        @Query('cursor', CursorValidationPipe) cursor?: CursorDto | undefined
     ): Promise<PaginatedResponseDto<TaskCardDTO>> {
         return await this.tasksService.getTasksMoreByUser(userId, projectId, cursor);
     }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #390

## ✅ 작업 내용

- 나의 업무 조회 API 응답 수정
- 복합 커서 직렬화/역직렬화 유틸 분리
- 복합 커서의 유효성 체크를 위한 파이프 추가

## 📎 기타 참고사항

- 페이지네이션 응답을 중첩하여 사용하는 것 보다 커서 값의 null 여부로 `더보기` 컴포넌트의 필요 여부를 충분히 판단할 수 있을 것 같아 응답 구조를 코드와 같이 수정하였습니다.
- 복합 커서 사용시 JSON 직렬화/역직렬화에 대한 로직을 유틸로 분리했습니다. 비슷한 기능을 사용하게 될 때 활용하면 좋을 것 같아요~